### PR TITLE
Parse exceptions into a custom objects for serialization.

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceResult.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceResult.java
@@ -1,7 +1,6 @@
 package com.squareup.spoon;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import com.squareup.spoon.misc.StackTrace;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -22,18 +21,18 @@ public final class DeviceResult {
   private final Map<DeviceTest, DeviceTestResult> testResults;
   private final long started;
   private final long duration;
-  private final List<String> exceptions;
+  private final List<StackTrace> exceptions;
 
   private DeviceResult(boolean installFailed, String installMessage, DeviceDetails deviceDetails,
       Map<DeviceTest, DeviceTestResult> testResults, long started, long duration,
-      List<String> exceptions) {
+      List<StackTrace> exceptions) {
     this.installFailed = installFailed;
     this.installMessage = installMessage;
     this.deviceDetails = deviceDetails;
     this.started = started;
     this.testResults = unmodifiableMap(new HashMap<DeviceTest, DeviceTestResult>(testResults));
     this.duration = duration;
-    this.exceptions = unmodifiableList(new ArrayList<String>(exceptions));
+    this.exceptions = unmodifiableList(new ArrayList<StackTrace>(exceptions));
   }
 
   /**
@@ -76,7 +75,7 @@ public final class DeviceResult {
   }
 
   /** Exceptions that occurred during execution. */
-  public List<String> getExceptions() {
+  public List<StackTrace> getExceptions() {
     return exceptions;
   }
 
@@ -89,7 +88,7 @@ public final class DeviceResult {
     private final long started = new Date().getTime();
     private long start;
     private long duration = -1;
-    private final List<String> exceptions = new ArrayList<String>();
+    private final List<StackTrace> exceptions = new ArrayList<StackTrace>();
 
     public Builder addTestResultBuilder(DeviceTest test,
         DeviceTestResult.Builder methodResultBuilder) {
@@ -131,17 +130,15 @@ public final class DeviceResult {
       return this;
     }
 
-    public Builder addException(Throwable exception) {
-      checkNotNull(exception);
-      StringWriter sw = new StringWriter();
-      exception.printStackTrace(new PrintWriter(sw));
-      exceptions.add(sw.toString());
+    public Builder addException(Throwable throwable) {
+      checkNotNull(throwable);
+      exceptions.add(StackTrace.from(throwable));
       return this;
     }
 
     public Builder addException(String message) {
       checkNotNull(message);
-      exceptions.add(message);
+      exceptions.add(StackTrace.from(message));
       return this;
     }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
@@ -1,5 +1,6 @@
 package com.squareup.spoon;
 
+import com.squareup.spoon.misc.StackTrace;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,14 +16,14 @@ public final class DeviceTestResult {
   }
 
   private final Status status;
-  private final String exception;
+  private final StackTrace exception;
   private final long duration;
   private final List<File> screenshots;
   private final File animatedGif;
   private final List<DeviceLogMessage> log;
 
-  private DeviceTestResult(Status status, String exception, long duration, List<File> screenshots,
-      File animatedGif, List<DeviceLogMessage> log) {
+  private DeviceTestResult(Status status, StackTrace exception, long duration,
+      List<File> screenshots, File animatedGif, List<DeviceLogMessage> log) {
     this.status = status;
     this.exception = exception;
     this.duration = duration;
@@ -37,7 +38,7 @@ public final class DeviceTestResult {
   }
 
   /** Exception thrown during execution. */
-  public String getException() {
+  public StackTrace getException() {
     return exception;
   }
 
@@ -63,25 +64,25 @@ public final class DeviceTestResult {
   public static class Builder {
     private final List<File> screenshots = new ArrayList<File>();
     private Status status = Status.PASS;
-    private String exception;
+    private StackTrace exception;
     private long start;
     private long duration = -1;
     private File animatedGif;
     private List<DeviceLogMessage> log;
 
-    public Builder markTestAsFailed(String exception) {
-      checkNotNull(exception);
+    public Builder markTestAsFailed(String message) {
+      checkNotNull(message);
       checkArgument(status == Status.PASS, "Status was already marked as " + status);
       status = Status.FAIL;
-      this.exception = exception;
+      exception = StackTrace.from(message);
       return this;
     }
 
-    public Builder markTestAsError(String exception) {
-      checkNotNull(exception);
+    public Builder markTestAsError(String message) {
+      checkNotNull(message);
       checkArgument(status == Status.PASS, "Status was already marked as " + status);
       status = Status.ERROR;
-      this.exception = exception;
+      exception = StackTrace.from(message);
       return this;
     }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/HtmlDevice.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/HtmlDevice.java
@@ -1,5 +1,6 @@
 package com.squareup.spoon;
 
+import com.squareup.spoon.misc.StackTrace;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,9 +27,9 @@ final class HtmlDevice {
     DeviceDetails details = result.getDeviceDetails();
     String title = (details != null) ? details.getName() : serial;
 
-    List<HtmlUtils.StackTrace> exceptions = new ArrayList<HtmlUtils.StackTrace>();
-    for (String exception : result.getExceptions()) {
-      exceptions.add(HtmlUtils.parseException(exception));
+    List<HtmlUtils.ExceptionInfo> exceptions = new ArrayList<HtmlUtils.ExceptionInfo>();
+    for (StackTrace exception : result.getExceptions()) {
+      exceptions.add(HtmlUtils.processStackTrace(exception));
     }
 
     StringBuilder subtitle = new StringBuilder();
@@ -52,10 +53,10 @@ final class HtmlDevice {
   public final String subtitle;
   public final List<TestResult> testResults;
   public final boolean hasExceptions;
-  public final List<HtmlUtils.StackTrace> exceptions;
+  public final List<HtmlUtils.ExceptionInfo> exceptions;
 
   HtmlDevice(String serial, String title, String subtitle, List<TestResult> testResults,
-      List<HtmlUtils.StackTrace> exceptions) {
+      List<HtmlUtils.ExceptionInfo> exceptions) {
     this.serial = serial;
     this.title = title;
     this.subtitle = subtitle;
@@ -77,7 +78,7 @@ final class HtmlDevice {
         screenshots.add(HtmlUtils.getScreenshot(screenshot, output));
       }
       String animatedGif = HtmlUtils.createRelativeUri(result.getAnimatedGif(), output);
-      HtmlUtils.StackTrace exception = HtmlUtils.parseException(result.getException());
+      HtmlUtils.ExceptionInfo exception = HtmlUtils.processStackTrace(result.getException());
       return new TestResult(serial, className, methodName, classSimpleName, prettyMethodName,
           testId, status, screenshots, animatedGif, exception);
     }
@@ -92,12 +93,12 @@ final class HtmlDevice {
     public final boolean hasScreenshots;
     public final List<HtmlUtils.Screenshot> screenshots;
     public final String animatedGif;
-    public final HtmlUtils.StackTrace exception;
+    public final HtmlUtils.ExceptionInfo exception;
 
     TestResult(String serial, String className, String methodName, String classSimpleName,
         String prettyMethodName, String testId, String status,
         List<HtmlUtils.Screenshot> screenshots, String animatedGif,
-        HtmlUtils.StackTrace exception) {
+        HtmlUtils.ExceptionInfo exception) {
       this.serial = serial;
       this.className = className;
       this.methodName = methodName;

--- a/spoon-runner/src/main/java/com/squareup/spoon/HtmlTest.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/HtmlTest.java
@@ -77,7 +77,7 @@ final class HtmlTest {
         screenshots.add(HtmlUtils.getScreenshot(screenshot, output));
       }
       String animatedGif = HtmlUtils.createRelativeUri(result.getAnimatedGif(), output);
-      HtmlUtils.StackTrace exception = HtmlUtils.parseException(result.getException());
+      HtmlUtils.ExceptionInfo exception = HtmlUtils.processStackTrace(result.getException());
 
       return new TestResult(name, serial, status, screenshots, animatedGif, exception);
     }
@@ -88,10 +88,10 @@ final class HtmlTest {
     public final boolean hasScreenshots;
     public final List<HtmlUtils.Screenshot> screenshots;
     public final String animatedGif;
-    public final HtmlUtils.StackTrace exception;
+    public final HtmlUtils.ExceptionInfo exception;
 
     TestResult(String name, String serial, String status, List<HtmlUtils.Screenshot> screenshots,
-        String animatedGif, HtmlUtils.StackTrace exception) {
+        String animatedGif, HtmlUtils.ExceptionInfo exception) {
       this.name = name;
       this.serial = serial;
       this.status = status;

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonInstrumentationInfo.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonInstrumentationInfo.java
@@ -36,6 +36,10 @@ final class SpoonInstrumentationInfo {
     return testRunnerClass;
   }
 
+  @Override public String toString() {
+    return ToStringBuilder.reflectionToString(this);
+  }
+
   /** Parse key information from an instrumentation APK's manifest. */
   static SpoonInstrumentationInfo parseFromFile(File apkTestFile) {
     InputStream is = null;
@@ -87,9 +91,5 @@ final class SpoonInstrumentationInfo {
     } finally {
       IOUtils.closeQuietly(is);
     }
-  }
-
-  @Override public String toString() {
-    return ToStringBuilder.reflectionToString(this);
   }
 }

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonLogger.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonLogger.java
@@ -6,7 +6,7 @@ import java.util.Date;
 
 /** Simple logger interface. */
 final class SpoonLogger {
-  private static final ThreadLocal<DateFormat> dateFormat = new ThreadLocal<DateFormat>() {
+  private static final ThreadLocal<DateFormat> DATE_FORMAT = new ThreadLocal<DateFormat>() {
     @Override protected DateFormat initialValue() {
       return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
     }
@@ -26,7 +26,7 @@ final class SpoonLogger {
     String className = stackTrace[3].getClassName();
     String methodName = stackTrace[3].getMethodName();
     className = className.replaceAll("[a-z\\.]", "");
-    String timestamp = dateFormat.get().format(new Date());
+    String timestamp = DATE_FORMAT.get().format(new Date());
     return String.format("%s [%s.%s] ", timestamp, className, methodName);
   }
 }

--- a/spoon-runner/src/main/java/com/squareup/spoon/misc/StackTrace.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/misc/StackTrace.java
@@ -1,0 +1,184 @@
+package com.squareup.spoon.misc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/** A representation of {@link Throwable} suitable for serialization. */
+public class StackTrace {
+  private static final Pattern HEADER = Pattern.compile("(?:Caused by: )?([^:]+)(?:: (.*))?");
+  private static final Pattern MORE = Pattern.compile("\\.\\.\\. \\d+ more");
+  private static final Pattern ELEMENT =
+      Pattern.compile("\\s*at (.*?)\\.([^.(]+)\\((?:([^:]+):(\\d+)|Native Method)\\)");
+
+  /** Convert a {@link Throwable} to its equivalent {@link StackTrace}. */
+  public static StackTrace from(Throwable exception) {
+    checkNotNull(exception);
+
+    StackTrace cause = null;
+    Throwable realCause = exception.getCause();
+    if (realCause != null && realCause != exception) {
+      cause = from(realCause);
+    }
+
+    List<Element> elements = new ArrayList<Element>();
+    for (StackTraceElement element : exception.getStackTrace()) {
+      elements.add(Element.from(element));
+    }
+
+    String className = exception.getClass().getCanonicalName();
+    String message = exception.getMessage();
+    return new StackTrace(className, message, elements, cause);
+  }
+
+  public static StackTrace from(String exception) {
+    checkNotNull(exception);
+    String parts[] = exception.replace("\r\n", "\n").split("\n");
+
+    StackTrace last = null;
+    List<String> messageParts = new ArrayList<String>();
+    List<Element> elements = new ArrayList<Element>();
+    boolean matchingElements = true; // Assume we will be matching elements first (bottom, up).
+    for (int i = parts.length - 1; i >= 0; i--) {
+      String part = parts[i];
+
+      Matcher elementMatch = ELEMENT.matcher(part);
+      Matcher moreMatch = MORE.matcher(part);
+      boolean moreMatches = moreMatch.matches();
+      if (elementMatch.matches() || moreMatches) {
+        if (!matchingElements) {
+          last = acceptTrace(messageParts, elements, last);
+          elements.clear();
+          messageParts.clear();
+        }
+        matchingElements = true;
+
+        if (!moreMatches) {
+          String className = elementMatch.group(1);
+          String methodName = elementMatch.group(2);
+          String fileName = elementMatch.group(3);
+          boolean isNative = fileName == null;
+          int line = isNative ? 0 : Integer.parseInt(elementMatch.group(4));
+
+          elements.add(0, new Element(className, fileName, line, methodName, isNative));
+        }
+      } else {
+        matchingElements = false;
+        messageParts.add(0, part);
+      }
+    }
+
+    return acceptTrace(messageParts, elements, last);
+  }
+
+  private static StackTrace acceptTrace(List<String> messageParts, List<Element> elements,
+      StackTrace last) {
+    String header = messageParts.remove(0);
+    Matcher headerMatch = HEADER.matcher(header);
+    if (!headerMatch.matches()) {
+      throw new IllegalStateException("Couldn't match exception header.");
+    }
+    messageParts.add(0, headerMatch.group(2));
+    String exceptionClass = headerMatch.group(1);
+    String message = StringUtils.join(messageParts, "\n");
+    if (message.equals("")) {
+      message = null;
+    }
+    return new StackTrace(exceptionClass, message, elements, last);
+  }
+
+  private final String className;
+  private final String message;
+  private final List<Element> elements;
+  private final StackTrace cause;
+
+  public StackTrace(String className, String message, List<Element> elements, StackTrace cause) {
+    checkNotNull(elements);
+
+    this.className = className;
+    this.message = message;
+    this.elements = Collections.unmodifiableList(new ArrayList<Element>(elements));
+    this.cause = cause;
+  }
+
+  public String getClassName() {
+    return className;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public List<Element> getElements() {
+    return elements;
+  }
+
+  public StackTrace getCause() {
+    return cause;
+  }
+
+  @Override public String toString() {
+    if (className != null) {
+      if (message != null) {
+        return className + ": " + message;
+      }
+      return className;
+    }
+    return message;
+  }
+
+  /** A representation of {@link StackTraceElement} suitable for serialization. */
+  public static class Element {
+    static Element from(StackTraceElement e) {
+      return new Element(e.getClassName(), e.getFileName(), e.getLineNumber(), e.getMethodName(),
+          e.isNativeMethod());
+    }
+
+    private final String className;
+    private final String fileName;
+    private final int line;
+    private final String methodName;
+    private final boolean isNative;
+
+    public Element(String className, String fileName, int line, String methodName,
+        boolean isNative) {
+      this.className = className;
+      this.fileName = fileName;
+      this.line = line;
+      this.methodName = methodName;
+      this.isNative = isNative;
+    }
+
+    public String getClassName() {
+      return className;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+
+    public int getLine() {
+      return line;
+    }
+
+    public String getMethodName() {
+      return methodName;
+    }
+
+    public boolean isNative() {
+      return isNative;
+    }
+
+    @Override public String toString() {
+      if (isNative) {
+        return String.format("%s.%s(Native Method)", className, methodName);
+      }
+      return String.format("%s.%s(%s:%d)", className, methodName, fileName, line);
+    }
+  }
+}

--- a/spoon-runner/src/main/resources/device.html
+++ b/spoon-runner/src/main/resources/device.html
@@ -23,10 +23,10 @@
                 <div class="span12">
                     {{#exceptions}}
                     <div class="alert alert-error stacktrace">
-                        <h4 data-toggle="collapse" data-target="#stacktrace-{{id}}">{{title}}</h4>
+                        <h4 data-toggle="collapse" data-target="#stacktrace-{{id}}">{{{title}}}</h4>
                         <div class="alert-error stacktrace-body collapse" id="stacktrace-{{id}}">
                             {{#body}}
-                            <div class="stacktrace-line">{{toString}}</div>
+                            <div class="stacktrace-line">{{{toString}}}</div>
                             {{/body}}
                         </div>
                     </div>
@@ -54,10 +54,10 @@
                     </h2>
                     {{#exception}}
                     <div class="alert alert-error stacktrace {{status}}">
-                        <h4 data-toggle="collapse" data-target="#stacktrace-{{id}}">{{title}}</h4>
+                        <h4 data-toggle="collapse" data-target="#stacktrace-{{id}}">{{{title}}}</h4>
                         <div class="stacktrace-body collapse" id="stacktrace-{{id}}">
                             {{#body}}
-                            <div class="stacktrace-line">{{toString}}</div>
+                            <div class="stacktrace-line">{{{toString}}}</div>
                             {{/body}}
                         </div>
                     </div>

--- a/spoon-runner/src/main/resources/spoon.less
+++ b/spoon-runner/src/main/resources/spoon.less
@@ -36,7 +36,7 @@ body {
 }
 
 .stacktrace {
-  overflow-y: auto;
+  overflow-y: scroll;
   margin-bottom: 10px;
 
   &.error {
@@ -52,7 +52,6 @@ body {
   }
   .stacktrace-line {
     white-space: nowrap;
-    margin-left: 1em;
   }
 }
 

--- a/spoon-runner/src/main/resources/test.html
+++ b/spoon-runner/src/main/resources/test.html
@@ -38,10 +38,10 @@
                     </h2>
                     {{#exception}}
                     <div class="alert alert-error stacktrace {{status}}">
-                        <h4 data-toggle="collapse" data-target="#stacktrace-{{serial}}">{{title}}</h4>
+                        <h4 data-toggle="collapse" data-target="#stacktrace-{{serial}}">{{{title}}}</h4>
                         <div class="stacktrace-body collapse" id="stacktrace-{{serial}}">
                             {{#body}}
-                            <div class="stacktrace-line">{{toString}}</div>
+                            <div class="stacktrace-line">{{{toString}}}</div>
                             {{/body}}
                         </div>
                     </div>

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
@@ -58,7 +58,7 @@ public class SpoonRunnerTest {
             .startTests() //
             .addTestResultBuilder(device, new DeviceTestResult.Builder() //
                 .startTest() //
-                .markTestAsFailed("Failed")
+                .markTestAsFailed("java.fake.Exception: Failed!")
                 .endTest()) //
             .build()) //
         .end() //
@@ -73,7 +73,7 @@ public class SpoonRunnerTest {
             .startTests() //
             .addTestResultBuilder(device, new DeviceTestResult.Builder() //
                 .startTest() //
-                .markTestAsError("Failed")
+                .markTestAsError("java.fake.Exception: Failed!")
                 .endTest()) //
             .build()) //
         .end() //

--- a/spoon-runner/src/test/java/com/squareup/spoon/misc/StackTraceTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/misc/StackTraceTest.java
@@ -1,0 +1,169 @@
+package com.squareup.spoon.misc;
+
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class StackTraceTest {
+  @Test public void recursiveCause() {
+    Exception spied = spy(new IllegalArgumentException("To understand recursion..."));
+    when(spied.getCause()).thenReturn(spied);
+
+    StackTrace actual = StackTrace.from(spied);
+    assertThat(actual.getCause()).isNull();
+  }
+
+  @Test public void nullCause() {
+    Exception t = new IllegalStateException("Null cause.", null);
+    StackTrace actual = StackTrace.from(t);
+    assertThat(actual.getClassName()).isEqualTo("java.lang.IllegalStateException");
+    assertThat(actual.getMessage()).isEqualTo("Null cause.");
+    assertThat(actual.getCause()).isNull();
+  }
+
+  @Test public void stringException() {
+    String exception = ""
+        + "java.lang.RuntimeException: Explicitly testing unexpected exceptions!\n"
+        + "at com.example.spoon.ordering.tests.MiscellaneousTest.testAnotherLongNameBecauseItIsHumorousAndTestingThingsLikeThisIsImportant(MiscellaneousTest.java:11)\n"
+        + "at java.lang.reflect.Method.invokeNative(Native Method)\n"
+        + "at android.test.InstrumentationTestCase.runMethod(InstrumentationTestCase.java:214)\n"
+        + "at android.test.InstrumentationTestCase.runTest(InstrumentationTestCase.java:199)\n"
+        + "at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:190)\n"
+        + "at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:175)\n"
+        + "at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:555)\n"
+        + "at com.example.spoon.ordering.tests.SpoonInstrumentationTestRunner.onStart(SpoonInstrumentationTestRunner.java:36)\n"
+        + "at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1661)";
+
+    StackTrace actual = StackTrace.from(exception);
+    assertThat(actual.getClassName()).isEqualTo("java.lang.RuntimeException");
+    assertThat(actual.getMessage()).isEqualTo("Explicitly testing unexpected exceptions!");
+    assertThat(actual.getCause()).isNull();
+    assertThat(actual.getElements()).hasSize(9);
+
+    StackTrace.Element elementOne = actual.getElements().get(0);
+    assertThat(elementOne.getClassName()) //
+        .isEqualTo("com.example.spoon.ordering.tests.MiscellaneousTest");
+    assertThat(elementOne.getMethodName()) //
+        .isEqualTo("testAnotherLongNameBecauseItIsHumorousAndTestingThingsLikeThisIsImportant");
+    assertThat(elementOne.getFileName()).isEqualTo("MiscellaneousTest.java");
+    assertThat(elementOne.getLine()).isEqualTo(11);
+    assertThat(elementOne.isNative()).isFalse();
+
+    StackTrace.Element elementTwo = actual.getElements().get(1);
+    assertThat(elementTwo.getClassName()).isEqualTo("java.lang.reflect.Method");
+    assertThat(elementTwo.getMethodName()).isEqualTo("invokeNative");
+    assertThat(elementTwo.getFileName()).isNull();
+    assertThat(elementTwo.getLine()).isZero();
+    assertThat(elementTwo.isNative()).isTrue();
+  }
+
+  @Test public void noMessage() {
+    String exception = ""
+        + "java.lang.NullPointerException\n"
+        + "at com.example.spoon.ordering.tests.MiscellaneousTest.test(MiscellaneousTest.java:11)";
+
+    StackTrace actual = StackTrace.from(exception);
+    assertThat(actual.getClassName()).isEqualTo("java.lang.NullPointerException");
+    assertThat(actual.getMessage()).isNull();
+    assertThat(actual.getCause()).isNull();
+    assertThat(actual.getElements()).hasSize(1);
+  }
+
+  @Test public void nestedStringException() {
+    String exception = ""
+        + "java.lang.NullPointerException: Hello to the world.\n"
+        + "at com.example.spoon.ordering.tests.MiscellaneousTest.test(MiscellaneousTest.java:11)\n"
+        + "Caused by: java.lang.IllegalArgumentException: Inner exception.\n"
+        + "at com.example.spoon.ordering.tests.Other.otherTest(Other.java:12)\n"
+        + "at com.example.spoon.ordering.tests.Other.things(Other.java:22)";
+
+    StackTrace actual = StackTrace.from(exception);
+    assertThat(actual.getClassName()).isEqualTo("java.lang.NullPointerException");
+    assertThat(actual.getMessage()).isEqualTo("Hello to the world.");
+    assertThat(actual.getCause()).isNotNull();
+    assertThat(actual.getElements()).hasSize(1);
+
+    StackTrace inner = actual.getCause();
+    assertThat(inner.getClassName()).isEqualTo("java.lang.IllegalArgumentException");
+    assertThat(inner.getMessage()).isEqualTo("Inner exception.");
+    assertThat(inner.getCause()).isNull();
+    assertThat(inner.getElements()).hasSize(2);
+  }
+
+  @Test public void multiLineException() {
+    String exception = ""
+        + "java.lang.AssertionError: Expected:\n"
+        + "<4>\n"
+        + "but was:\n"
+        + "<8>\n"
+        + "at com.example.spoon.ordering.tests.MiscellaneousTest.test(MiscellaneousTest.java:11)";
+
+    StackTrace actual = StackTrace.from(exception);
+    assertThat(actual.getClassName()).isEqualTo("java.lang.AssertionError");
+    assertThat(actual.getMessage()).isEqualTo("Expected:\n<4>\nbut was:\n<8>");
+    assertThat(actual.getCause()).isNull();
+    assertThat(actual.getElements()).hasSize(1);
+  }
+
+  @Test public void nestedMultiLineException() {
+    String exception = ""
+        + "java.lang.NullPointerException: Hello to the world.\n"
+        + "at com.example.spoon.ordering.tests.MiscellaneousTest.test(MiscellaneousTest.java:11)\n"
+        + "Caused by: java.lang.AssertionError: Expected:\n"
+        + "<4>\n"
+        + "but was:\n"
+        + "<8>\n"
+        + "at com.example.spoon.ordering.tests.Other.otherTest(Other.java:12)\n"
+        + "at com.example.spoon.ordering.tests.Other.things(Other.java:22)";
+
+    StackTrace actual = StackTrace.from(exception);
+    assertThat(actual.getClassName()).isEqualTo("java.lang.NullPointerException");
+    assertThat(actual.getMessage()).isEqualTo("Hello to the world.");
+    assertThat(actual.getCause()).isNotNull();
+    assertThat(actual.getElements()).hasSize(1);
+
+    StackTrace inner = actual.getCause();
+    assertThat(inner.getClassName()).isEqualTo("java.lang.AssertionError");
+    assertThat(inner.getMessage()).isEqualTo("Expected:\n" + "<4>\n" + "but was:\n" + "<8>");
+    assertThat(inner.getCause()).isNull();
+    assertThat(inner.getElements()).hasSize(2);
+  }
+
+  @Test public void nestedExceptionWithMore() {
+    String exception = ""
+        + "java.lang.NullPointerException: Hello to the world.\n"
+        + "at com.example.spoon.ordering.tests.MiscellaneousTest.test(MiscellaneousTest.java:11)\n"
+        + "Caused by: java.lang.AssertionError: Broken\n"
+        + "at com.example.spoon.ordering.tests.Other.otherTest(Other.java:12)\n"
+        + "... 12 more";
+
+    StackTrace actual = StackTrace.from(exception);
+    assertThat(actual.getClassName()).isEqualTo("java.lang.NullPointerException");
+    assertThat(actual.getMessage()).isEqualTo("Hello to the world.");
+    assertThat(actual.getCause()).isNotNull();
+    assertThat(actual.getElements()).hasSize(1);
+
+    StackTrace inner = actual.getCause();
+    assertThat(inner.getClassName()).isEqualTo("java.lang.AssertionError");
+    assertThat(inner.getMessage()).isEqualTo("Broken");
+    assertThat(inner.getCause()).isNull();
+    assertThat(inner.getElements()).hasSize(1);
+  }
+
+  @Test public void toStringFormat() {
+    List<StackTrace.Element> elements = Collections.emptyList();
+
+    StackTrace onlyClass = new StackTrace("java.lang.NullPointerException", null, elements, null);
+    assertThat(onlyClass.toString()).isEqualTo("java.lang.NullPointerException");
+
+    StackTrace onlyMessage = new StackTrace(null, "Hello, World!", elements, null);
+    assertThat(onlyMessage.toString()).isEqualTo("Hello, World!");
+
+    StackTrace both = new StackTrace("java.lang.NullPointerException", "Hi, Mom!", elements, null);
+    assertThat(both.toString()).isEqualTo("java.lang.NullPointerException: Hi, Mom!");
+  }
+}

--- a/spoon-sample/tests/src/main/java/com/example/spoon/ordering/tests/MiscellaneousTest.java
+++ b/spoon-sample/tests/src/main/java/com/example/spoon/ordering/tests/MiscellaneousTest.java
@@ -8,6 +8,10 @@ public class MiscellaneousTest extends InstrumentationTestCase {
   }
 
   public void testAnotherLongNameBecauseItIsHumorousAndTestingThingsLikeThisIsImportant() {
-    throw new RuntimeException("Explicitly testing unexpected exceptions!");
+    try {
+      throw new RuntimeException("Messages can have...\n...newlines.");
+    } catch (RuntimeException e) {
+      throw new IllegalStateException("Explicitly testing unexpected, nested exceptions.", e);
+    }
   }
 }


### PR DESCRIPTION
This brings better display of exceptions as well. Proper nesting for inner-exceptions and newlines in messages are now supported.

Closes #21. Closes #22.
