### PR TITLE
Fixing mvn spoon:run

### DIFF
--- a/spoon-maven-plugin/pom.xml
+++ b/spoon-maven-plugin/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.directory.studio</groupId>
+      <artifactId>org.apache.commons.io</artifactId>
+      <version>2.4</version>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
I used Commons-IO to get hold of apk files, as it seems that Artifact.getFile() is not suitable for this job (fetching local/module dependencies). Provided method is little bit of hack, but after deploying locally I was able successfully run `mvn spoon:run`
This should fix Issue #50 now.
