### PR TITLE
Add check on android SDK location to prevent NPE.

### DIFF
--- a/spoon-maven-plugin/src/main/java/com/squareup/spoon/SpoonMojo.java
+++ b/spoon-maven-plugin/src/main/java/com/squareup/spoon/SpoonMojo.java
@@ -119,10 +119,14 @@ public class SpoonMojo extends AbstractMojo {
       return;
     }
 
+    if (androidSdk == null) {
+      throw new MojoExecutionException(
+          "Could not find Android SDK. Ensure ANDROID_HOME environment variable is set.");
+    }
     File sdkFile = new File(androidSdk);
     if (!sdkFile.exists()) {
       throw new MojoExecutionException(
-          "Could not find Android SDK. Ensure ANDROID_HOME environment variable is set.");
+          String.format("Could not find Android SDK at: %s", androidSdk));
     }
     log.debug("Android SDK: " + sdkFile.getAbsolutePath());
 


### PR DESCRIPTION
androidSdk can be null if ANDROID_HOME is not defined, so the
extra checks prevents an NPE.
Also added the location of the SDK in the error message when
the location does not exist.
