### PR TITLE
Show API level in device name for AVDs

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceDetails.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceDetails.java
@@ -14,7 +14,7 @@ public final class DeviceDetails {
 
   private DeviceDetails(String name, String manufacturer, String version, int apiLevel,
       String language, String region) {
-    this.name = name;
+    this.name = "sdk".equals(name) ?  name + "-" + apiLevel : name;
     this.manufacturer = manufacturer;
     this.version = version;
     this.apiLevel = apiLevel;


### PR DESCRIPTION
When running spoon with multiple AVDs it's difficult to distinguish the devices.
This little patch shows AVD's SDK level in it's name.
