### PR TITLE
Fix 'provied' in README, should be 'provided'

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ application.
   <artifactId>example-app</artifactId>
   <version>${project.version}</version>
   <type>jar</type>
-  <scope>provied</scope>
+  <scope>provided</scope>
 </dependency>
 <dependency>
   <groupId>com.example</groupId>
   <artifactId>example-app</artifactId>
   <version>${project.version}</version>
   <type>apk</type>
-  <scope>provied</scope>
+  <scope>provided</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
A minor README fix. Sorry for the lack of feature branch, this was a quick edit on GitHub.
