### PR TITLE
Adding 'headless' java param to spoon runner

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -96,7 +96,8 @@ public final class SpoonDeviceRunner {
     // Kick off a new process to interface with ADB and perform the real execution.
     String name = SpoonDeviceRunner.class.getName();
     Process process =
-        new ProcessBuilder("java", "-cp", classpath, name, work.getAbsolutePath()).start();
+        new ProcessBuilder("java", "-Djava.awt.headless=true", "-cp", classpath, name,
+        work.getAbsolutePath()).start();
     printStream(process.getInputStream(), "STDOUT");
     printStream(process.getErrorStream(), "STDERR");
 


### PR DESCRIPTION
Currently, the spoon runner shows at OS X's dock while running as shown at the screenshot below (and probably other OS's UI too).
This patch adds the "headless" param to the java command line to prevent this behavior.

![screen shot 2013-05-14 at 2 07 06 pm](https://f.cloud.github.com/assets/21069/537582/a8eff114-c175-11e2-8da6-f67704bb02c1.png)
