### PR TITLE
Test identifier adapter for support of other test runners

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
+import com.squareup.spoon.adapters.TestIdentifierAdapter;
 
 import static com.android.ddmlib.FileListingService.FileEntry;
 import static com.squareup.spoon.Spoon.SPOON_SCREENSHOTS;
@@ -136,6 +137,8 @@ public final class SpoonDeviceRunner {
     String appPackage = instrumentationInfo.getApplicationPackage();
     String testPackage = instrumentationInfo.getInstrumentationPackage();
     String testRunner = instrumentationInfo.getTestRunnerClass();
+    TestIdentifierAdapter testIdentifierAdapter = TestIdentifierAdapter.fromTestRunner(testRunner);
+    
     logDebug(debug, "InstrumentationInfo: [%s]", instrumentationInfo);
 
     if (debug) {
@@ -192,7 +195,7 @@ public final class SpoonDeviceRunner {
         runner.setTestSize(testSize);
       }
       runner.run(
-          new SpoonTestRunListener(result, debug),
+          new SpoonTestRunListener(result, debug, testIdentifierAdapter),
           new XmlTestRunListener(junitReport)
       );
     } catch (Exception e) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/adapters/TestIdentifierAdapter.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/adapters/TestIdentifierAdapter.java
@@ -1,0 +1,35 @@
+package com.squareup.spoon.adapters;
+
+import org.apache.commons.lang3.text.WordUtils;
+
+import com.android.ddmlib.testrunner.TestIdentifier;
+
+public enum TestIdentifierAdapter {
+
+  JUNIT() {
+    @Override
+    public TestIdentifier adapt(TestIdentifier test) {
+      return test;
+    }
+  },
+  CUCUMBER() {
+    @Override
+    public TestIdentifier adapt(TestIdentifier test) {
+      String className = WordUtils.capitalize(test.getClassName()).replaceAll(
+          "[^a-zA-Z0-9_]+", "");
+      String testName = "test"
+          + WordUtils.capitalize(test.getTestName()).replaceAll(
+              "[^a-zA-Z0-9_]+", "");
+
+      return new TestIdentifier(className, testName);
+    }
+  };
+
+  private static final String CUCUMBER_NAME = "cucumber.api.android.CucumberInstrumentation";
+
+  public abstract TestIdentifier adapt(TestIdentifier test);
+
+  public static TestIdentifierAdapter fromTestRunner(String name) {
+    return CUCUMBER_NAME.equals(name) ? CUCUMBER : JUNIT;
+  }
+}

--- a/spoon-runner/src/test/java/com/squareup/spoon/adapters/TestIdentifierAdapterTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/adapters/TestIdentifierAdapterTest.java
@@ -1,0 +1,39 @@
+package com.squareup.spoon.adapters;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.android.ddmlib.testrunner.TestIdentifier;
+
+public class TestIdentifierAdapterTest {
+
+  @Test
+  public void otherAdapter() {
+    TestIdentifierAdapter adapter = TestIdentifierAdapter
+        .fromTestRunner("other.adapter");
+
+    TestIdentifier test = new TestIdentifier("ThisIsATest",
+        "testThisIsATestMethod");
+
+    assertEquals(test, adapter.adapt(test));
+  }
+
+  @Test
+  public void cucumberAdapter() {
+    TestIdentifierAdapter adapter = TestIdentifierAdapter
+        .fromTestRunner("cucumber.api.android.CucumberInstrumentation");
+
+    assertEquals(new TestIdentifier("ThisIsATest", "testThisIsATestMethod"),
+        adapter.adapt(new TestIdentifier("This is a test!",
+            "This is a test method!")));
+    assertEquals(new TestIdentifier("NonAlphanumericCharactersConvertLookGood",
+        "testFor500IGet300"), adapter.adapt(new TestIdentifier(
+        "Non alpha-numeric characters convert & look good!",
+        "For $500 I get £300")));
+    assertEquals(new TestIdentifier("ThisIsAbadtest", "testVeryBadTest"),
+        adapter.adapt(new TestIdentifier(
+            "This@£$%^&*Is£$%^&*A£$%^&*bad$£%^&*test",
+            "Very£$%^&Bad$%^&*:|{}Test")));
+  }
+}


### PR DESCRIPTION
Currently spoon can run and collect test information from standard android tests, where test methods are prefixed with "test" since this is a requirement of JUnit 3.x.

This pull request allows spoon to adapt the TestIdentifier by using a TestIdentifierAdapter which is created based on a factory method TestIdentifierAdapter.create(String), where String is the qualified name of the test runner.

Tests running from cucumber-jvm for Android use pretty names for test class (feature) and test name (scenario), a CucumberTestIdentifierAdapter has been provided that will make these names compatible with spoon.

This is probably a crude solution but it works and would be great to get feedback from the spoon team to make the solution better.
