### PR TITLE
Bump some dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
       <dependency>
         <groupId>com.beust</groupId>
         <artifactId>jcommander</artifactId>
-        <version>1.30</version>
+        <version>1.32</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
This explicitly fixes parsing of arguments containing spaces on Windows.

Closes #117.

@edenman  
