### PR TITLE
Ensure device serials are properly sanitized for file system use.

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -40,6 +40,7 @@ public final class SpoonDeviceRunner {
   private static final String FILE_RESULT = "result.json";
   static final String TEMP_DIR = "work";
   static final String JUNIT_DIR = "junit-reports";
+  static final String IMAGE_DIR = "image";
 
   private final File sdk;
   private final File apk;
@@ -48,12 +49,12 @@ public final class SpoonDeviceRunner {
   private final boolean debug;
   private final boolean noAnimations;
   private final int adbTimeout;
-  private final File output;
   private final String className;
   private final String methodName;
   private final IRemoteAndroidTestRunner.TestSize testSize;
   private final File work;
   private final File junitReport;
+  private final File imageDir;
   private final String classpath;
   private final SpoonInstrumentationInfo instrumentationInfo;
 
@@ -74,8 +75,9 @@ public final class SpoonDeviceRunner {
    *        {@code className}.
    */
   SpoonDeviceRunner(File sdk, File apk, File testApk, File output, String serial, boolean debug,
-      boolean noAnimations, int adbTimeout, String classpath, SpoonInstrumentationInfo instrumentationInfo,
-      String className, String methodName, IRemoteAndroidTestRunner.TestSize testSize) {
+      boolean noAnimations, int adbTimeout, String classpath,
+      SpoonInstrumentationInfo instrumentationInfo, String className, String methodName,
+      IRemoteAndroidTestRunner.TestSize testSize) {
     this.sdk = sdk;
     this.apk = apk;
     this.testApk = testApk;
@@ -83,14 +85,16 @@ public final class SpoonDeviceRunner {
     this.debug = debug;
     this.noAnimations = noAnimations;
     this.adbTimeout = adbTimeout;
-    this.output = output;
     this.className = className;
     this.methodName = methodName;
     this.testSize = testSize;
-    this.work = FileUtils.getFile(output, TEMP_DIR, serial);
-    this.junitReport = FileUtils.getFile(output, JUNIT_DIR, serial + ".xml");
     this.classpath = classpath;
     this.instrumentationInfo = instrumentationInfo;
+
+    serial = SpoonUtils.sanitizeSerial(serial);
+    this.work = FileUtils.getFile(output, TEMP_DIR, serial);
+    this.junitReport = FileUtils.getFile(output, JUNIT_DIR, serial + ".xml");
+    this.imageDir = FileUtils.getFile(output, IMAGE_DIR, serial);
   }
 
   /** Serialize to disk and start {@link #main(String...)} in another process. */
@@ -223,7 +227,6 @@ public final class SpoonDeviceRunner {
 
       File screenshotDir = new File(work, dirName);
       if (screenshotDir.exists()) {
-        File imageDir = FileUtils.getFile(output, "image", serial);
         imageDir.mkdirs();
 
         // Move all children of the screenshot directory into the image folder.


### PR DESCRIPTION
Closes #140.

@edenman @holmes 

```
$ find spoon-sample/tests/target/spoon-output -type d
spoon-sample/tests/target/spoon-output
spoon-sample/tests/target/spoon-output/device
spoon-sample/tests/target/spoon-output/image
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.LoginActivityTest
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.LoginActivityTest/testBlankPassword_ShowsError
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.LoginActivityTest/testBlankUsername_ShowsError
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.LoginActivityTest/testEmptyForm_ShowsBothErrors
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.LoginActivityTest/testPasswordTooShort_ShowsError
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.LoginActivityTest/testValidValues_StartsNewActivity
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.OrderActivityTest
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.OrderActivityTest/testMakeASandwich_ItTastesGood
spoon-sample/tests/target/spoon-output/image/192_168_56_101_5555/com.example.spoon.ordering.tests.OrderActivityTest/testMakeSomeSalad_ItIsHealthy
spoon-sample/tests/target/spoon-output/junit-reports
spoon-sample/tests/target/spoon-output/logs
spoon-sample/tests/target/spoon-output/logs/192_168_56_101_5555
spoon-sample/tests/target/spoon-output/logs/192_168_56_101_5555/com.example.spoon.ordering.tests.LoginActivityTest
spoon-sample/tests/target/spoon-output/logs/192_168_56_101_5555/com.example.spoon.ordering.tests.MiscellaneousTest
spoon-sample/tests/target/spoon-output/logs/192_168_56_101_5555/com.example.spoon.ordering.tests.OrderActivityTest
spoon-sample/tests/target/spoon-output/static
spoon-sample/tests/target/spoon-output/test
spoon-sample/tests/target/spoon-output/test/com.example.spoon.ordering.tests.LoginActivityTest
spoon-sample/tests/target/spoon-output/test/com.example.spoon.ordering.tests.MiscellaneousTest
spoon-sample/tests/target/spoon-output/test/com.example.spoon.ordering.tests.OrderActivityTest
spoon-sample/tests/target/spoon-output/work
spoon-sample/tests/target/spoon-output/work/192_168_56_101_5555
```

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Spoon (Parent) .................................... SUCCESS [0.710s]
[INFO] Spoon Client Library .............................. SUCCESS [2.776s]
[INFO] Spoon Runner ...................................... SUCCESS [4.634s]
[INFO] Spoon Maven Plugin ................................ SUCCESS [2.841s]
[INFO] Spoon Sample (Parent) ............................. SUCCESS [0.004s]
[INFO] Spoon Sample Application .......................... SUCCESS [22.433s]
[INFO] Spoon Sample Instrumentation ...................... SUCCESS [1:29.404s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 2:03.609s
[INFO] Finished at: Thu Oct 24 10:59:14 PDT 2013
[INFO] Final Memory: 59M/830M
[INFO] ------------------------------------------------------------------------
```
