### PR TITLE
Update execution parameters on website to match the README

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -106,7 +106,9 @@ Spoon.screenshot(activity, "after_login");</pre>
     --title             Execution title
     --class-name        Test class name to run (fully-qualified)
     --method-name       Test method name to run (must also use --class-name)</pre>
-
+    --no-animations     Disable animated gif generation
+    --size              Only run test methods annotated by testSize (small, medium, large)
+    --adb-timeout       Set maximum execution time per test in seconds (10min default)
             <h4 id="maven">Maven</h4>
             <p>If you are using Maven for compilation, a plugin is provided for easy execution. Declare the plugin in the <code>pom.xml</code> for the instrumentation test module.</p>
             <pre class="prettyprint">&lt;plugin>


### PR DESCRIPTION
Noticed that the website did not list all the same command line args as the README.

This PR updates the website to match.
