### PR TITLE
TV mode: tests following a failed test are viewed as failing too

### DIFF
--- a/spoon-runner/src/main/resources/page/tv.html
+++ b/spoon-runner/src/main/resources/page/tv.html
@@ -56,7 +56,7 @@
             }
 
             function updateTest(testResult) {
-                $('#current-test-info').removeClass('pass', 'fail', 'error')
+                $('#current-test-info').removeClass('pass fail error')
                 $('#current-test-info').addClass(testResult.status)
                 $('#test-name').text(testResult.methodPrettyName)
                 $('#test-class-name').text(testResult.classSimpleName)


### PR DESCRIPTION
The CSS class 'fail' is never removed, caused by a bad usage of the jquery removeClass function.
