### PR TITLE
Fix google fonts not loaded over https

### DIFF
--- a/spoon-runner/src/main/resources/page/device.html
+++ b/spoon-runner/src/main/resources/page/device.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{title}}</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="../static/bootstrap.min.css" rel="stylesheet">
         <link href="../static/bootstrap-responsive.min.css" rel="stylesheet">
         <link href="../static/spoon.css" rel="stylesheet">

--- a/spoon-runner/src/main/resources/page/index.html
+++ b/spoon-runner/src/main/resources/page/index.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{title}}</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="static/bootstrap.min.css" rel="stylesheet">
         <link href="static/bootstrap-responsive.min.css" rel="stylesheet">
         <link href="static/spoon.css" rel="stylesheet">

--- a/spoon-runner/src/main/resources/page/log.html
+++ b/spoon-runner/src/main/resources/page/log.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{title}}</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="../../../static/bootstrap.min.css" rel="stylesheet">
         <link href="../../../static/bootstrap-responsive.min.css" rel="stylesheet">
         <link href="../../../static/spoon.css" rel="stylesheet">

--- a/spoon-runner/src/main/resources/page/test.html
+++ b/spoon-runner/src/main/resources/page/test.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{title}}</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="../../static/bootstrap.min.css" rel="stylesheet">
         <link href="../../static/bootstrap-responsive.min.css" rel="stylesheet">
         <link href="../../static/spoon.css" rel="stylesheet">

--- a/spoon-runner/src/main/resources/page/tv.html
+++ b/spoon-runner/src/main/resources/page/tv.html
@@ -4,7 +4,7 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{{title}}</title>
-        <link href="http://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Roboto:regular,medium,thin,italic,mediumitalic,bold" rel="stylesheet">
         <link href="static/bootstrap.min.css" rel="stylesheet">
         <link href="static/bootstrap-responsive.min.css" rel="stylesheet">
         <link href="static/spoon.css" rel="stylesheet">


### PR DESCRIPTION
Fixes #183. When serving spoon runner content over https browser fails
to load fonts because it refuses to load unsecured content.
