### PR TITLE
Supports adding a screenshot to the report

### DIFF
--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -62,6 +62,46 @@ public final class Spoon {
     }
   }
 
+    /**
+     * Save a existent screenshot to the report using the specified tag.
+     *
+     * @param bitmap Bitmap that represents the screenshot.
+     * @param context Context of the Activity that was used.
+     * @param tag Unique tag to further identify the screenshot. Must match [a-zA-Z0-9_-]+.
+     * @return the image file that was created
+     */
+    public static File saveScreenshot(Bitmap bitmap, Context context, String tag) {
+        if (!TAG_VALIDATION.matcher(tag).matches()) {
+            throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
+        }
+        try {
+            File screenshotDirectory = obtainScreenshotDirectory(context);
+            String screenshotName = System.currentTimeMillis() + NAME_SEPARATOR + tag + EXTENSION;
+            File screenshotFile = new File(screenshotDirectory, screenshotName);
+            saveScreenshot(screenshotFile, bitmap);
+            Log.d(TAG, "Captured screenshot '" + tag + "'.");
+            return screenshotFile;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to capture screenshot.", e);
+        }
+    }
+
+    private static void saveScreenshot(File file, final Bitmap bitmap) throws IOException {
+        OutputStream fos = null;
+        try {
+            fos = new BufferedOutputStream(new FileOutputStream(file));
+            bitmap.compress(PNG, 100 /* quality */, fos);
+
+            chmodPlusR(file);
+        } finally {
+            bitmap.recycle();
+            if (fos != null) {
+                fos.close();
+            }
+        }
+    }
+
+
   private static void takeScreenshot(File file, final Activity activity) throws IOException {
     View view = activity.getWindow().getDecorView();
     final Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), ARGB_8888);


### PR DESCRIPTION
Hello guys,

I'm using spoon in my projects, but the screenshot method has some limitations to my needs, so I'm adding support to include screenshots to the report, so you can use another method to take screenshots and just pass them to spoon.

So far I found three important scenarios where spoon current screenshot method does not work:
- Dialogs
- Google Maps
- External Apps

For google maps, what I found (not tested) is that the GoogleMap itself has a snapshot method, so I can use it, and get the bitmap for the report.
For external apps, what I tested was to use the getInstrumentation().getUiAutomation().takeScreenshot(). We have several scenarios in our app that we send the user to external apps, so this function worked for it. The limitation is that this method is only available for api 18+, so does not seems a good option to be included in spoon screenshot method.

I still need to add some kind of test to the sample to show it working, maybe someone can help me with that. 

Thank you,
Lucio
