### PR TITLE
Screenshot method with methodName and className parameters

### DIFF
--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -43,11 +43,24 @@ public final class Spoon {
    * @return the image file that was created
    */
   public static File screenshot(Activity activity, String tag) {
+    return screenshot(activity, null, null, tag);
+  }
+
+  /**
+   * Take a screenshot with the specified tag.
+   *
+   * @param activity Activity with which to capture a screenshot.
+   * @param className The name of the test class  
+   * @param methodName The name of the test method
+   * @param tag Unique tag to further identify the screenshot. Must match [a-zA-Z0-9_-]+.
+   * @return the image file that was created
+   */
+  public static File screenshot(Activity activity, String className, String methodName, String tag) {
     if (!TAG_VALIDATION.matcher(tag).matches()) {
       throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
     }
     try {
-      File screenshotDirectory = obtainScreenshotDirectory(activity);
+      File screenshotDirectory = obtainScreenshotDirectory(activity, className, methodName);
       String screenshotName = System.currentTimeMillis() + NAME_SEPARATOR + tag + EXTENSION;
       File screenshotFile = new File(screenshotDirectory, screenshotName);
       takeScreenshot(screenshotFile, activity);
@@ -105,7 +118,7 @@ public final class Spoon {
     activity.getWindow().getDecorView().draw(canvas);
   }
 
-  private static File obtainScreenshotDirectory(Context context) throws IllegalAccessException {
+  private static File obtainScreenshotDirectory(Context context, String className, String methodName) throws IllegalAccessException {
     File screenshotsDir = context.getDir(SPOON_SCREENSHOTS, MODE_WORLD_READABLE);
 
     synchronized (LOCK) {
@@ -114,11 +127,16 @@ public final class Spoon {
         outputNeedsClear = false;
       }
     }
+    
+    if(className == null || methodName == null){
+      // No information provided by user, try to find it in the stack trace
+      StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
+      className = testClass.getClassName();
+      methodName = testClass.getMethodName();
+    }
 
-    StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
-    String className = testClass.getClassName().replaceAll("[^A-Za-z0-9._-]", "_");
-    File dirClass = new File(screenshotsDir, className);
-    File dirMethod = new File(dirClass, testClass.getMethodName());
+    File dirClass = new File(screenshotsDir, className.replaceAll("[^A-Za-z0-9._-]", "_"));
+    File dirMethod = new File(dirClass, methodName);
     createDir(dirMethod);
     return dirMethod;
   }

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -50,12 +50,13 @@ public final class Spoon {
    * Take a screenshot with the specified tag.
    *
    * @param activity Activity with which to capture a screenshot.
-   * @param className The name of the test class  
+   * @param className The name of the test class
    * @param methodName The name of the test method
    * @param tag Unique tag to further identify the screenshot. Must match [a-zA-Z0-9_-]+.
    * @return the image file that was created
    */
-  public static File screenshot(Activity activity, String className, String methodName, String tag) {
+  public static File screenshot(Activity activity, String className, String methodName,
+                                String tag) {
     if (!TAG_VALIDATION.matcher(tag).matches()) {
       throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
     }
@@ -118,7 +119,9 @@ public final class Spoon {
     activity.getWindow().getDecorView().draw(canvas);
   }
 
-  private static File obtainScreenshotDirectory(Context context, String className, String methodName) throws IllegalAccessException {
+  private static File obtainScreenshotDirectory(Context context, String className,
+                                                String methodName)
+          throws IllegalAccessException {
     File screenshotsDir = context.getDir(SPOON_SCREENSHOTS, MODE_WORLD_READABLE);
 
     synchronized (LOCK) {
@@ -127,10 +130,10 @@ public final class Spoon {
         outputNeedsClear = false;
       }
     }
-    
-    if(className == null || methodName == null){
+    if (className == null || methodName == null) {
       // No information provided by user, try to find it in the stack trace
-      StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
+      StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+      StackTraceElement testClass = findTestClassTraceElement(stackTrace);
       className = testClass.getClassName();
       methodName = testClass.getMethodName();
     }


### PR DESCRIPTION
This is a pull request for issue #202. 

Moreover the screenshot method is broken with JUnit4 because stack trace is different. I think It could be nice to let the client give the details about method name and class name. In our case we use a modified version of the TestWatcher rule to get those informations.

``` java
    @Rule
    public final ExtendedTestWatcher testWatcher = new ExtendedTestWatcher();

    public void takeScreenshot(String tag) {
        Spoon.screenshot(getCurrentActivity(), testWatcher.className(), testWatcher.methodName(), tag);
    }
```