### PR TITLE
added parameter -e <NAME> <VALUE> for SpoonRunner.

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -15,6 +15,8 @@ import com.google.common.collect.Multimap;
 import com.squareup.spoon.adapters.TestIdentifierAdapter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.apache.commons.lang3.tuple.Pair;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -62,6 +64,7 @@ public final class SpoonDeviceRunner {
   private final String classpath;
   private final SpoonInstrumentationInfo instrumentationInfo;
   private final List<ITestRunListener> testRunListeners;
+  private final Pair<String, String> runnerArg;
 
   /**
    * Create a test runner for a single device.
@@ -79,11 +82,13 @@ public final class SpoonDeviceRunner {
    * @param methodName Test method name to run or {@code null} to run all tests.  Must also pass
    *        {@code className}.
    * @param testRunListeners Additional TestRunListener or empty list.
+   * @param runnerArg Argument of test runner or {@code null} if extra argument is not needed.
    */
   SpoonDeviceRunner(File sdk, File apk, File testApk, File output, String serial, boolean debug,
       boolean noAnimations, int adbTimeout, String classpath,
       SpoonInstrumentationInfo instrumentationInfo, String className, String methodName,
-      IRemoteAndroidTestRunner.TestSize testSize, List<ITestRunListener> testRunListeners) {
+      IRemoteAndroidTestRunner.TestSize testSize, List<ITestRunListener> testRunListeners,
+      Pair<String, String> runnerArg) {
     this.sdk = sdk;
     this.apk = apk;
     this.testApk = testApk;
@@ -102,6 +107,7 @@ public final class SpoonDeviceRunner {
     this.junitReport = FileUtils.getFile(output, JUNIT_DIR, serial + ".xml");
     this.imageDir = FileUtils.getFile(output, IMAGE_DIR, serial);
     this.testRunListeners = testRunListeners;
+    this.runnerArg = runnerArg;
   }
 
   /** Serialize to disk and start {@link #main(String...)} in another process. */
@@ -199,6 +205,9 @@ public final class SpoonDeviceRunner {
       }
       if (testSize != null) {
         runner.setTestSize(testSize);
+      }
+      if (runnerArg != null) {
+        runner.addInstrumentationArg(runnerArg.getKey(), runnerArg.getValue());
       }
       List<ITestRunListener> listeners = new ArrayList<ITestRunListener>();
       listeners.add(new SpoonTestRunListener(result, debug, testIdentifierAdapter));


### PR DESCRIPTION
Hello.

It might be useful to use test runners with "extra" additional parameters.
 
E.g. I need to run spoon only for functional tests (These are tests that derive from InstrumentationTestCase) 
InstrumentationTestRunner allows to do this, using '-e func true' 
here -e paramater set the 'func' argument with value 'true'

However, currently it is not possible to pass 'extra' argument to test runner.

This commit adds -e <NAME> <VALUE> parameter to command line arguments of spoon-runner, and to SpoonRunner.Builder so it will be possible to pass parameters to the runner.