### PR TITLE
Support JUnit4 tests that don't extend InstrumentationTestCase

### DIFF
--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -27,8 +27,10 @@ import static com.squareup.spoon.Chmod.chmodPlusRWX;
 public final class Spoon {
   static final String SPOON_SCREENSHOTS = "spoon-screenshots";
   static final String NAME_SEPARATOR = "_";
-  static final String TEST_CASE_CLASS = "android.test.InstrumentationTestCase";
-  static final String TEST_CASE_METHOD = "runMethod";
+  static final String TEST_CASE_CLASS_JUNIT_3 = "android.test.InstrumentationTestCase";
+  static final String TEST_CASE_METHOD_JUNIT_3 = "runMethod";
+  static final String TEST_CASE_CLASS_JUNIT_4 = "org.junit.runners.model.FrameworkMethod$1";
+  static final String TEST_CASE_METHOD_JUNIT_4 = "runReflectiveCall";
   private static final String EXTENSION = ".png";
   private static final String TAG = "Spoon";
   private static final Object LOCK = new Object();
@@ -136,8 +138,14 @@ public final class Spoon {
   static StackTraceElement findTestClassTraceElement(StackTraceElement[] trace) {
     for (int i = trace.length - 1; i >= 0; i--) {
       StackTraceElement element = trace[i];
-      if (TEST_CASE_CLASS.equals(element.getClassName()) //
-          && TEST_CASE_METHOD.equals(element.getMethodName())) {
+
+      if (TEST_CASE_CLASS_JUNIT_3.equals(element.getClassName()) //
+          && TEST_CASE_METHOD_JUNIT_3.equals(element.getMethodName())) {
+        return trace[i - 3];
+      }
+
+      if (TEST_CASE_CLASS_JUNIT_4.equals(element.getClassName()) //
+              && TEST_CASE_METHOD_JUNIT_4.equals(element.getMethodName())) {
         return trace[i - 3];
       }
     }

--- a/spoon-client/src/test/java/com/squareup/spoon/SpoonTest.java
+++ b/spoon-client/src/test/java/com/squareup/spoon/SpoonTest.java
@@ -5,9 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 
-import static com.squareup.spoon.Spoon.TEST_CASE_CLASS;
-import static com.squareup.spoon.Spoon.TEST_CASE_METHOD;
-import static com.squareup.spoon.Spoon.findTestClassTraceElement;
+import static com.squareup.spoon.Spoon.*;
 import static org.fest.assertions.api.Assertions.assertThat;
 
 // TODO custom test runner, fill out what the ?s actually are
@@ -39,7 +37,7 @@ public class SpoonTest {
     StackTraceElement actual = findTestClassTraceElement(new StackTraceBuilder() //
         .add("some.Class", "someMethod", "Class.java", 1)
         .add("this.That", "thatThis", "That.java", 2)
-        .add(TEST_CASE_CLASS, TEST_CASE_METHOD, "A.java", 3)
+        .add(TEST_CASE_CLASS_JUNIT_3, TEST_CASE_METHOD_JUNIT_3, "A.java", 3)
         .add("?", "?", "?", 0)
         .add("?", "?", "?", 0)
         .add(EXPECTED_CLASS, EXPECTED_METHOD, "Whatever.java", 50)
@@ -55,7 +53,7 @@ public class SpoonTest {
     StackTraceElement actual = findTestClassTraceElement(new StackTraceBuilder() //
         .add("some.Class", "someMethod", "Class.java", 1)
         .add("this.That", "thatThis", "That.java", 2)
-        .add(TEST_CASE_CLASS, TEST_CASE_METHOD, "A.java", 3)
+        .add(TEST_CASE_CLASS_JUNIT_3, TEST_CASE_METHOD_JUNIT_3, "A.java", 3)
         .add("?", "?", "?", 0)
         .add("?", "?", "?", 0)
         .add(EXPECTED_CLASS, EXPECTED_METHOD, "Whatever.java", 50)
@@ -64,6 +62,37 @@ public class SpoonTest {
         .add(SCREENSHOT, "obtainScreenshotDirectory", "Spoon.java", 40)
         .build());
 
+    assertThat(actual.getClassName()).isEqualTo(EXPECTED_CLASS);
+    assertThat(actual.getMethodName()).isEqualTo(EXPECTED_METHOD);
+  }
+
+  @Test public void directScreenshotCallJUnit4() {
+    StackTraceElement actual = findTestClassTraceElement(new StackTraceBuilder() //
+        .add("some.Class", "someMethod", "Class.java", 1)
+        .add("this.That", "thatThis", "That.java", 2)
+        .add(TEST_CASE_CLASS_JUNIT_4, TEST_CASE_METHOD_JUNIT_4, "A.java", 3)
+        .add("java.lang.reflect.Method", "invoke", "Native Invoke", 0)
+        .add("java.lang.reflect.Method", "invokeNative", "Method.java", 515)
+        .add(EXPECTED_CLASS, EXPECTED_METHOD, "Whatever.java", 50)
+        .add(SCREENSHOT, "screenshot", "Spoon.java", 30)
+        .add(SCREENSHOT, "obtainScreenshotDirectory", "Spoon.java", 40)
+        .build());
+    assertThat(actual.getClassName()).isEqualTo(EXPECTED_CLASS);
+    assertThat(actual.getMethodName()).isEqualTo(EXPECTED_METHOD);
+  }
+
+  @Test public void withConvenienceMethodCallJUnit4() {
+    StackTraceElement actual = findTestClassTraceElement(new StackTraceBuilder() //
+        .add("some.Class", "someMethod", "Class.java", 1)
+        .add("this.That", "thatThis", "That.java", 2)
+        .add(TEST_CASE_CLASS_JUNIT_4, TEST_CASE_METHOD_JUNIT_4, "A.java", 3)
+        .add("java.lang.reflect.Method", "invoke", "Native Invoke", 0)
+        .add("java.lang.reflect.Method", "invokeNative", "Method.java", 515)
+        .add(EXPECTED_CLASS, EXPECTED_METHOD, "Whatever.java", 50)
+        .add("com.example.Utils", "captureScreen", "Utils.java", 100)
+        .add(SCREENSHOT, "screenshot", "Spoon.java", 30)
+        .add(SCREENSHOT, "obtainScreenshotDirectory", "Spoon.java", 40)
+        .build());
     assertThat(actual.getClassName()).isEqualTo(EXPECTED_CLASS);
     assertThat(actual.getMethodName()).isEqualTo(EXPECTED_METHOD);
   }


### PR DESCRIPTION
`Spoon#findTestClassTraceElement()` expects an entry in the stack trace for the method `android.test.InstrumentationTestCase.runMethod()`. When running a JUnit 4 test case, this entry does not exist and an `IllegalArgumentException` will be thrown. 

Inspecting stack traces for a pure JUnit4 test on api 16+, I think it is safe to make the assumption there will always be an entry in the stack trace for `org.junit.runners.model.FrameworkMethod$1.runReflectiveCall()`. The method under test is always three positions below that entry in the stack trace. 

refs #232