### PR TITLE
Avoid calling adb.terminate()

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -97,26 +97,21 @@ public final class SpoonRunner {
 
     AndroidDebugBridge adb = SpoonUtils.initAdb(androidSdk);
 
-    try {
-      // If we were given an empty serial set, load all available devices.
-      Set<String> serials = this.serials;
-      if (serials.isEmpty()) {
-        serials = SpoonUtils.findAllDevices(adb);
-      }
-      if (failIfNoDeviceConnected && serials.isEmpty()) {
-        throw new RuntimeException("No device(s) found.");
-      }
-
-      // Execute all the things...
-      SpoonSummary summary = runTests(adb, serials);
-      // ...and render to HTML
-      new HtmlRenderer(summary, SpoonUtils.GSON, output).render();
-
-      return parseOverallSuccess(summary);
-    } finally {
-      AndroidDebugBridge.disconnectBridge();
-      AndroidDebugBridge.terminate();
+    // If we were given an empty serial set, load all available devices.
+    Set<String> serials = this.serials;
+    if (serials.isEmpty()) {
+      serials = SpoonUtils.findAllDevices(adb);
     }
+    if (failIfNoDeviceConnected && serials.isEmpty()) {
+      throw new RuntimeException("No device(s) found.");
+    }
+
+    // Execute all the things...
+    SpoonSummary summary = runTests(adb, serials);
+    // ...and render to HTML
+    new HtmlRenderer(summary, SpoonUtils.GSON, output).render();
+
+    return parseOverallSuccess(summary);
   }
 
   private SpoonSummary runTests(AndroidDebugBridge adb, Set<String> serials) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
@@ -97,7 +97,7 @@ final class SpoonUtils {
 
   /** Get an {@link com.android.ddmlib.AndroidDebugBridge} instance given an SDK path. */
   static AndroidDebugBridge initAdb(File sdk) {
-    AndroidDebugBridge.init(false);
+    AndroidDebugBridge.initIfNeeded(false);
     File adbPath = FileUtils.getFile(sdk, "platform-tools", "adb");
     AndroidDebugBridge adb = AndroidDebugBridge.createBridge(adbPath.getAbsolutePath(), true);
     waitForAdb(adb);


### PR DESCRIPTION
This implementation should be closer to what Android Gradle plugin does.
They use `initIfNeeded` in `ConnectedDevice` before creating an ADB instance
and do not call `terminate()`.

To be honest I haven't tested this thoroughly but I believe it's the correct way.
See also https://github.com/square/spoon/issues/203#issuecomment-82151163

This also should allow to run parallel spoon runner tasks.