### PR TITLE
Provide arbitrary instrumentationArgs name value 

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -10,7 +10,6 @@ import com.android.ddmlib.logcat.LogCatMessage;
 import com.android.ddmlib.testrunner.IRemoteAndroidTestRunner;
 import com.android.ddmlib.testrunner.ITestRunListener;
 import com.android.ddmlib.testrunner.RemoteAndroidTestRunner;
-import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.squareup.spoon.adapters.TestIdentifierAdapter;
@@ -29,6 +28,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 
 import static com.android.ddmlib.FileListingService.FileEntry;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.squareup.spoon.Spoon.SPOON_SCREENSHOTS;
 import static com.squareup.spoon.SpoonLogger.logDebug;
 import static com.squareup.spoon.SpoonLogger.logError;
@@ -54,6 +54,7 @@ public final class SpoonDeviceRunner {
   private final boolean debug;
   private final boolean noAnimations;
   private final int adbTimeout;
+  private final List<String> instrumentationArgs;
   private final String className;
   private final String methodName;
   private final IRemoteAndroidTestRunner.TestSize testSize;
@@ -83,8 +84,9 @@ public final class SpoonDeviceRunner {
    */
   SpoonDeviceRunner(File sdk, File apk, File testApk, File output, String serial, boolean debug,
       boolean noAnimations, int adbTimeout, String classpath,
-      SpoonInstrumentationInfo instrumentationInfo, String className, String methodName,
-      IRemoteAndroidTestRunner.TestSize testSize, List<ITestRunListener> testRunListeners) {
+      SpoonInstrumentationInfo instrumentationInfo, List<String> instrumentationArgs,
+                    String className, String methodName, IRemoteAndroidTestRunner.TestSize testSize,
+                    List<ITestRunListener> testRunListeners) {
     this.sdk = sdk;
     this.apk = apk;
     this.testApk = testApk;
@@ -92,6 +94,7 @@ public final class SpoonDeviceRunner {
     this.debug = debug;
     this.noAnimations = noAnimations;
     this.adbTimeout = adbTimeout;
+    this.instrumentationArgs = instrumentationArgs;
     this.className = className;
     this.methodName = methodName;
     this.testSize = testSize;
@@ -196,8 +199,19 @@ public final class SpoonDeviceRunner {
       logDebug(debug, "About to actually run tests for [%s]", serial);
       RemoteAndroidTestRunner runner = new RemoteAndroidTestRunner(testPackage, testRunner, device);
       runner.setMaxtimeToOutputResponse(adbTimeout);
-      if (!Strings.isNullOrEmpty(className)) {
-        if (Strings.isNullOrEmpty(methodName)) {
+
+      if (instrumentationArgs != null && instrumentationArgs.size() > 0) {
+        for (String pair : instrumentationArgs) {
+          String[] kvp = pair.split("=");
+          if (kvp.length != 2 || isNullOrEmpty(kvp[0]) || isNullOrEmpty(kvp[1])) {
+            continue;
+          }
+          runner.addInstrumentationArg(kvp[0], kvp[1]);
+        }
+      }
+
+      if (!isNullOrEmpty(className)) {
+        if (isNullOrEmpty(methodName)) {
           runner.setClassName(className);
         } else {
           runner.setMethodName(className, methodName);

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -7,7 +7,6 @@ import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.squareup.spoon.html.HtmlRenderer;
 
@@ -393,8 +392,8 @@ public final class SpoonRunner {
     public File testApk;
 
     @Parameter(names = { "--e" },
-        description = "Arguments to pass to the Instrumentation Runner. This can be used multiple times for multiple entries." +
-            " Usage: --e <NAME>=<VALUE>." )
+        description = "Arguments to pass to the Instrumentation Runner. This can be used multiple"
+            + " times for multiple entries. Usage: --e <NAME>=<VALUE>.")
     public List<String> instrumentationArgs;
 
     @Parameter(names = { "--class-name" }, description = "Test class name to run (fully-qualified)")


### PR DESCRIPTION
Very similar to pull request #237; this adds the ability to provide additional args to the Android Instrumentation Runner. 
The major variation is this allows multiple args. Difference is that the parameter string is later split on an equals sign (=) then passed into the runner.addInstrumentationArg method; 
Example: --e package=com.example.test --e func=true