### PR TITLE
implement --wake-devices argument

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceResult.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceResult.java
@@ -23,10 +23,11 @@ public final class DeviceResult {
   private final long started;
   private final long duration;
   private final List<StackTrace> exceptions;
+  private final boolean wakeUpFailed;
 
   private DeviceResult(boolean installFailed, String installMessage, DeviceDetails deviceDetails,
       Map<DeviceTest, DeviceTestResult> testResults, long started, long duration,
-      List<StackTrace> exceptions) {
+      List<StackTrace> exceptions, boolean wakeUpFailed) {
     this.installFailed = installFailed;
     this.installMessage = installMessage;
     this.deviceDetails = deviceDetails;
@@ -34,6 +35,7 @@ public final class DeviceResult {
     this.testResults = unmodifiableMap(new TreeMap<DeviceTest, DeviceTestResult>(testResults));
     this.duration = duration;
     this.exceptions = unmodifiableList(new ArrayList<StackTrace>(exceptions));
+    this.wakeUpFailed = wakeUpFailed;
   }
 
   /**
@@ -80,6 +82,13 @@ public final class DeviceResult {
     return exceptions;
   }
 
+  /**
+   * {@code true} if device failed to wake up.
+   */
+  public boolean getWakeUpFailed() {
+    return wakeUpFailed;
+  }
+
   static class Builder {
     private boolean installFailed = false;
     private String installMessage = null;
@@ -90,6 +99,7 @@ public final class DeviceResult {
     private long start;
     private long duration = -1;
     private final List<StackTrace> exceptions = new ArrayList<StackTrace>();
+    private boolean wakeUpFailed = false;
 
     public Builder addTestResultBuilder(DeviceTest test,
         DeviceTestResult.Builder methodResultBuilder) {
@@ -114,6 +124,11 @@ public final class DeviceResult {
       checkArgument(!installFailed, "Install already marked as failed.");
       installFailed = true;
       installMessage = message;
+      return this;
+    }
+
+    public Builder markWakeUpFailed() {
+      wakeUpFailed = true;
       return this;
     }
 
@@ -151,7 +166,7 @@ public final class DeviceResult {
       }
 
       return new DeviceResult(installFailed, installMessage, deviceDetails, testResults, started,
-          duration, exceptions);
+          duration, exceptions, wakeUpFailed);
     }
   }
 }

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceWakeUp.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceWakeUp.java
@@ -1,0 +1,155 @@
+package com.squareup.spoon;
+
+import com.android.ddmlib.IDevice;
+import com.android.ddmlib.IShellOutputReceiver;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.squareup.spoon.SpoonLogger.logDebug;
+import static com.squareup.spoon.SpoonLogger.logError;
+
+/**
+ * rhodey (Open Whisper Systems, 2015)
+ */
+public class SpoonDeviceWakeUp extends Thread implements IShellOutputReceiver {
+
+  private static final long WAKE_UP_DELAY_MS       = 2500L;
+  private static final int  POWER_BUTTON_KEY_EVENT = 26;
+
+  private static final String DEVICE_AWAKE_QUERY          = "dumpsys input_method";
+  private static final String DEVICE_AWAKE_QUERY_LOLLIPOP = "dumpsys power";
+  private static final String DEVICE_AWAKE_REGEX          = ".*mScreenOn=(true|false).*";
+  private static final String DEVICE_AWAKE_REGEX_LOLLIPOP = ".*Display Power: state=(ON|OFF).*";
+
+  private enum State {
+    CHECK_DEVICE_AWAKE,
+    WAKE_UP_DEVICE,
+    VERIFY_DEVICE_AWAKE
+  }
+
+  private final IDevice       device;
+  private final DeviceDetails deviceDetails;
+  private final String        serial;
+  private final int           adbTimeout;
+  private final boolean       debug;
+
+  private State   state       = State.CHECK_DEVICE_AWAKE;
+  private boolean deviceAwake = false;
+  private String  shellOutput = "";
+
+  public SpoonDeviceWakeUp(IDevice device, DeviceDetails deviceDetails, String serial, int adbTimeout, boolean debug) {
+    this.device        = device;
+    this.deviceDetails = deviceDetails;
+    this.serial        = serial;
+    this.adbTimeout    = adbTimeout;
+    this.debug         = debug;
+  }
+
+  public boolean isDeviceAwake() {
+    return deviceAwake;
+  }
+
+  private synchronized void handleCheckDeviceAwake() {
+    try {
+
+      shellOutput = "";
+      logDebug(debug, "[%s] asking device if they are awake", serial);
+
+      if (deviceDetails.getApiLevel() < 21)
+        device.executeShellCommand(DEVICE_AWAKE_QUERY, this, adbTimeout, TimeUnit.MILLISECONDS);
+      else
+        device.executeShellCommand(DEVICE_AWAKE_QUERY_LOLLIPOP, this, adbTimeout, TimeUnit.MILLISECONDS);
+
+    } catch (Exception e) {
+      logError("[%s] device didn't like our shell command: %s", serial, e.toString());
+      notify();
+    }
+  }
+
+  private synchronized void handleWakeUpDevice() {
+    if (deviceAwake) {
+      notify();
+      return;
+    }
+
+    try {
+
+      logDebug(debug, "[%s] attempting to wake up device", serial);
+      device.executeShellCommand("input keyevent " + POWER_BUTTON_KEY_EVENT, this, adbTimeout, TimeUnit.MILLISECONDS);
+
+    } catch (Exception e) {
+      logError("[%s] device didn't like our shell command: %s", serial, e.toString());
+      notify();
+    }
+  }
+
+  @Override
+  public void run() {
+    handleCheckDeviceAwake();
+  }
+
+  @Override
+  public void addOutput(byte[] data, int offset, int length) {
+    if (length < 1 || data.length < (offset + length)) {
+      throw new AssertionError("length or offset doesn't make sense");
+    }
+
+    byte[] newData = new byte[length];
+    for (int i = 0; i < length; i++) {
+      newData[i] = data[offset + i];
+    }
+
+    shellOutput += new String(newData);
+  }
+
+  @Override
+  public void flush() {
+    Matcher deviceAwakeMatcher;
+    String  deviceAwakeCondition;
+
+    if (deviceDetails.getApiLevel() < 21) {
+      deviceAwakeMatcher   = Pattern.compile(DEVICE_AWAKE_REGEX, Pattern.DOTALL).matcher(shellOutput);
+      deviceAwakeCondition = "true";
+    } else {
+      deviceAwakeMatcher   = Pattern.compile(DEVICE_AWAKE_REGEX_LOLLIPOP, Pattern.DOTALL).matcher(shellOutput);
+      deviceAwakeCondition = "ON";
+    }
+
+    synchronized (this) {
+      if (!deviceAwakeMatcher.matches() && state != State.WAKE_UP_DEVICE) {
+        logError("[%s] unable to determine if device is awake", serial);
+        notify();
+        return;
+      }
+
+      switch (state) {
+        case CHECK_DEVICE_AWAKE:
+          deviceAwake = deviceAwakeMatcher.group(1).equals(deviceAwakeCondition);
+          state       = State.WAKE_UP_DEVICE;
+          handleWakeUpDevice();
+          break;
+
+        case WAKE_UP_DEVICE:
+          state = State.VERIFY_DEVICE_AWAKE;
+          try {
+            Thread.sleep(WAKE_UP_DELAY_MS);
+          } catch (InterruptedException e) { }
+          handleCheckDeviceAwake();
+          break;
+
+        case VERIFY_DEVICE_AWAKE:
+          deviceAwake = deviceAwakeMatcher.group(1).equals(deviceAwakeCondition);
+          notify();
+          break;
+      }
+    }
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+}


### PR DESCRIPTION
[Android espresso tests](https://code.google.com/p/android-test-kit/wiki/Espresso) require that a device is awake and unlocked, this PR solves the first of those two preconditions by adding a `--wake-devices` argument. I think `--wake-devices` is a sane default but in this PR it is initialized to `false` because `input keyevent 26` is known to be problematic on some early API levels (gingerbread & below) running on some strange devices. I'm hoping to gain more insight on how to reliably wake up early API, strange devices, if that comes it'll be another PR.