### PR TITLE
#285: Fix hardcoded 30s timeout.

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -433,7 +433,7 @@ public final class SpoonDeviceRunner {
       SpoonDeviceRunner target = GSON.fromJson(reader, SpoonDeviceRunner.class);
       reader.close();
 
-      AndroidDebugBridge adb = SpoonUtils.initAdb(target.sdk);
+      AndroidDebugBridge adb = SpoonUtils.initAdb(target.sdk, target.adbTimeout);
       DeviceResult result = target.run(adb);
       AndroidDebugBridge.terminate();
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -97,7 +97,7 @@ public final class SpoonRunner {
     checkArgument(applicationApk.exists(), "Could not find application APK.");
     checkArgument(instrumentationApk.exists(), "Could not find instrumentation APK.");
 
-    AndroidDebugBridge adb = SpoonUtils.initAdb(androidSdk);
+    AndroidDebugBridge adb = SpoonUtils.initAdb(androidSdk, adbTimeout);
 
     try {
       // If we were given an empty serial set, load all available devices.

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
@@ -97,11 +97,11 @@ final class SpoonUtils {
   }
 
   /** Get an {@link com.android.ddmlib.AndroidDebugBridge} instance given an SDK path. */
-  static AndroidDebugBridge initAdb(File sdk) {
+  static AndroidDebugBridge initAdb(File sdk, long timeOutMs) {
     AndroidDebugBridge.initIfNeeded(false);
     File adbPath = FileUtils.getFile(sdk, "platform-tools", "adb");
     AndroidDebugBridge adb = AndroidDebugBridge.createBridge(adbPath.getAbsolutePath(), false);
-    waitForAdb(adb);
+    waitForAdb(adb, timeOutMs);
     return adb;
   }
 
@@ -129,8 +129,7 @@ final class SpoonUtils {
     encoder.finish();
   }
 
-  private static void waitForAdb(AndroidDebugBridge adb) {
-    long timeOutMs = TimeUnit.SECONDS.toMillis(30);
+  private static void waitForAdb(AndroidDebugBridge adb, long timeOutMs) {
     long sleepTimeMs = TimeUnit.SECONDS.toMillis(1);
     while (!adb.hasInitialDeviceList() && timeOutMs > 0) {
       try {


### PR DESCRIPTION
Hello,

A small fix to link the initDB timeout to the existing adbTimeout.
