### PR TITLE
Make some Utils public

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
@@ -27,7 +27,7 @@ import static com.android.ddmlib.FileListingService.FileEntry;
 import static com.android.ddmlib.FileListingService.TYPE_DIRECTORY;
 
 /** Utilities for executing instrumentation tests on devices. */
-final class SpoonUtils {
+public final class SpoonUtils {
   private static final Pattern SERIAL_VALIDATION = Pattern.compile("[^a-zA-Z0-9_-]");
   static final Gson GSON = new GsonBuilder() //
       .registerTypeAdapter(File.class, new TypeAdapter<File>() {
@@ -88,7 +88,7 @@ final class SpoonUtils {
   }
 
   /** Find all device serials that are plugged in through ADB. */
-  static Set<String> findAllDevices(AndroidDebugBridge adb) {
+  public static Set<String> findAllDevices(AndroidDebugBridge adb) {
     Set<String> devices = new LinkedHashSet<String>();
     for (IDevice realDevice : adb.getDevices()) {
       devices.add(realDevice.getSerialNumber());
@@ -97,7 +97,7 @@ final class SpoonUtils {
   }
 
   /** Get an {@link com.android.ddmlib.AndroidDebugBridge} instance given an SDK path. */
-  static AndroidDebugBridge initAdb(File sdk, long timeOutMs) {
+  public static AndroidDebugBridge initAdb(File sdk, long timeOutMs) {
     AndroidDebugBridge.initIfNeeded(false);
     File adbPath = FileUtils.getFile(sdk, "platform-tools", "adb");
     AndroidDebugBridge adb = AndroidDebugBridge.createBridge(adbPath.getAbsolutePath(), false);


### PR DESCRIPTION
I'm currently using some methods from the `DeviceUtils` and `SpoonUtils` class for the https://github.com/x2on/gradle-spoon-plugin - Would be nice to not duplicate the code there and just use the Utils directly.