### PR TITLE
Added parameter that allows to execute a script file

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Options:
     --fail-on-failure   Non-zero exit code on failure
     --fail-if-no-device-connected Fail if no device is connected
     --sequential        Execute the tests device by device
+    --init-script       Path to a script that you want to run before each device
     --e                 Arguments to pass to the Instrumentation Runner. This can be used
                         multiple times for multiple entries. Usage: --e <NAME>=<VALUE>.
                         The supported arguments varies depending on which test runner 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -12,8 +12,10 @@ import com.squareup.spoon.html.HtmlRenderer;
 
 import org.apache.commons.io.FileUtils;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -57,12 +59,14 @@ public final class SpoonRunner {
   private final boolean failIfNoDeviceConnected;
   private final List<ITestRunListener> testRunListeners;
   private final boolean terminateAdb;
+  private File initScript;
 
   private SpoonRunner(String title, File androidSdk, File applicationApk, File instrumentationApk,
       File output, boolean debug, boolean noAnimations, int adbTimeout, Set<String> serials,
       String classpath, List<String> instrumentationArgs, String className, String methodName,
       IRemoteAndroidTestRunner.TestSize testSize, boolean failIfNoDeviceConnected,
-      List<ITestRunListener> testRunListeners, boolean sequential, boolean terminateAdb) {
+      List<ITestRunListener> testRunListeners, boolean sequential, File initScript,
+      boolean terminateAdb) {
     this.title = title;
     this.androidSdk = androidSdk;
     this.applicationApk = applicationApk;
@@ -80,6 +84,7 @@ public final class SpoonRunner {
     this.failIfNoDeviceConnected = failIfNoDeviceConnected;
     this.testRunListeners = testRunListeners;
     this.terminateAdb = terminateAdb;
+    this.initScript = initScript;
 
     if (sequential) {
       this.threadExecutor = Executors.newSingleThreadExecutor();
@@ -146,6 +151,7 @@ public final class SpoonRunner {
 
     if (targetCount == 1) {
       // Since there is only one device just execute it synchronously in this process.
+      executeInitScript();
       String serial = serials.iterator().next();
       String safeSerial = SpoonUtils.sanitizeSerial(serial);
       try {
@@ -159,6 +165,9 @@ public final class SpoonRunner {
         logDebug(debug, "[%s] Execution done.", serial);
       }
     } else {
+      // Execute a script before the first test on the thread executor if sequential mode on
+      threadExecutor.execute(getRunnableScript());
+
       // Spawn a new thread for each device and wait for them all to finish.
       final CountDownLatch done = new CountDownLatch(targetCount);
       final Set<String> remaining = synchronizedSet(new HashSet<String>(serials));
@@ -201,6 +210,43 @@ public final class SpoonRunner {
     }
 
     return summary.end().build();
+  }
+
+  /** Returns a {@link Runnable} to launch the script before/between devices in sequential mode. */
+  private Runnable getRunnableScript() {
+    return new Runnable() {
+      @Override
+      public void run() {
+        executeInitScript();
+      }
+    };
+  }
+
+  /** Execute the script file specified in param --init-script */
+  private void executeInitScript() {
+    if (initScript != null && initScript.exists()) {
+      try {
+        Runtime run = Runtime.getRuntime();
+        Process proc = run.exec(new String[] {
+                "/bin/bash", "-c", initScript.getAbsolutePath()
+        });
+        BufferedReader br = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+        String line;
+
+        logInfo("Output of running script is");
+        while ((line = br.readLine()) != null) {
+          logInfo(line);
+        }
+        proc.waitFor(); // Wait for the process to finish.
+        logInfo("Script executed successfully %s", initScript.getAbsolutePath());
+      } catch (IOException e) {
+        logDebug(debug, "Error executing script for path: %s", initScript.getAbsolutePath());
+        e.printStackTrace(System.out);
+      } catch (InterruptedException e) {
+        logDebug(debug, "Script execution interrupted for path: %s", initScript.getAbsolutePath());
+        e.printStackTrace(System.out);
+      }
+    }
   }
 
   /** Returns {@code false} if a test failed on any device. */
@@ -246,6 +292,7 @@ public final class SpoonRunner {
     private boolean failIfNoDeviceConnected;
     private List<ITestRunListener> testRunListeners = new ArrayList<ITestRunListener>();
     private boolean sequential;
+    private File initScript;
     private boolean terminateAdb = true;
 
     /** Identifying title for this execution. */
@@ -359,6 +406,14 @@ public final class SpoonRunner {
       return this;
     }
 
+    public Builder setInitScript(File initScript) {
+      checkNotNull(initScript, "Script path not specified.");
+      checkArgument(initScript.exists(), "Script path does not exist "
+              + initScript.getAbsolutePath());
+      this.initScript = initScript;
+      return this;
+    }
+
     public Builder setMethodName(String methodName) {
       this.methodName = methodName;
       return this;
@@ -389,7 +444,8 @@ public final class SpoonRunner {
 
       return new SpoonRunner(title, androidSdk, applicationApk, instrumentationApk, output, debug,
           noAnimations, adbTimeout, serials, classpath, instrumentationArgs, className, methodName,
-          testSize, failIfNoDeviceConnected, testRunListeners, sequential, terminateAdb);
+          testSize, failIfNoDeviceConnected, testRunListeners, sequential, initScript,
+          terminateAdb);
     }
   }
 
@@ -438,6 +494,11 @@ public final class SpoonRunner {
     @Parameter(names = { "--sequential" },
         description = "Execute tests sequentially (one device at a time)") //
     public boolean sequential;
+
+    @Parameter(names = { "--init-script" },
+            description = "Script file executed between each devices",
+            converter = FileConverter.class)
+    public File initScript;
 
     @Parameter(names = { "--no-animations" }, description = "Disable animated gif generation")
     public boolean noAnimations;
@@ -513,6 +574,7 @@ public final class SpoonRunner {
         .setAdbTimeout(parsedArgs.adbTimeoutSeconds * 1000)
         .setFailIfNoDeviceConnected(parsedArgs.failIfNoDeviceConnected)
         .setSequential(parsedArgs.sequential)
+        .setInitScript(parsedArgs.initScript)
         .setInstrumentationArgs(parsedArgs.instrumentationArgs)
         .setClassName(parsedArgs.className)
         .setMethodName(parsedArgs.methodName);


### PR DESCRIPTION
Hello @edenman 

I've seen that you merged a couple of pull requests recently.

This feature adds a --script parameter to spoon that allows to execute a script before the tests (in normal mode), or between each devices (in sequential mode).

I'm using myself this feature on a private deploy for my project for months now. I just did not have the time before to do a pull request. It allows me to reset my test server to zero before I run the test on each device connected to the platform (it's a ruby on rails server, so completely dissociated from the device).

I guess it can be used for other purposes too. Does this feature interest you?

I ran 'mvn install' and everything went fine (tests and checkstyle are passing).
Don't hesitate to answer if you want something changed in the code (naming, comments, logic etc...). I can easily do any change and squash it.

Thank you in advance.

Cheers,

Olivier