### PR TITLE
Default SpoonRunner.Builder's adbTimeout to a non-zero value.

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -288,7 +288,7 @@ public final class SpoonRunner {
     private String methodName;
     private boolean noAnimations;
     private IRemoteAndroidTestRunner.TestSize testSize;
-    private int adbTimeout;
+    private int adbTimeout = DEFAULT_ADB_TIMEOUT;
     private boolean failIfNoDeviceConnected;
     private List<ITestRunListener> testRunListeners = new ArrayList<ITestRunListener>();
     private boolean sequential;


### PR DESCRIPTION
After https://github.com/square/spoon/pull/287 the adbTimeout defaults to zero, which means if you are using the Spoon gradle plugin and haven't explicitly specified the adbTimeout config parameter, builds will fail.  See https://github.com/stanfy/spoon-gradle-plugin/issues/97. 

10 minutes seems perhaps a tad long, but using the existing DEFAULT_ADB_TIMEOUT seemed reasonable. :)