### PR TITLE
Fix for storing screenshots on Android M

### DIFF
--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.os.Looper;
 import android.util.Log;
 import android.view.View;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -26,258 +27,266 @@ import static android.graphics.Bitmap.Config.ARGB_8888;
 import static com.squareup.spoon.Chmod.chmodPlusR;
 import static com.squareup.spoon.Chmod.chmodPlusRWX;
 
-/** Utility class for capturing screenshots for Spoon. */
+/**
+ * Utility class for capturing screenshots for Spoon.
+ */
 public final class Spoon {
-  static final String SPOON_SCREENSHOTS = "spoon-screenshots";
-  static final String SPOON_FILES = "spoon-files";
-  static final String NAME_SEPARATOR = "_";
-  static final String TEST_CASE_CLASS_JUNIT_3 = "android.test.InstrumentationTestCase";
-  static final String TEST_CASE_METHOD_JUNIT_3 = "runMethod";
-  static final String TEST_CASE_CLASS_JUNIT_4 = "org.junit.runners.model.FrameworkMethod$1";
-  static final String TEST_CASE_METHOD_JUNIT_4 = "runReflectiveCall";
-  static final String TEST_CASE_CLASS_CUCUMBER_JVM = "cucumber.runtime.model.CucumberFeature";
-  static final String TEST_CASE_METHOD_CUCUMBER_JVM = "run";
-  private static final String EXTENSION = ".png";
-  private static final String TAG = "Spoon";
-  private static final Object LOCK = new Object();
-  private static final Pattern TAG_VALIDATION = Pattern.compile("[a-zA-Z0-9_-]+");
+    static final String SPOON_SCREENSHOTS = "spoon-screenshots";
+    static final String SPOON_FILES = "spoon-files";
+    static final String NAME_SEPARATOR = "_";
+    static final String TEST_CASE_CLASS_JUNIT_3 = "android.test.InstrumentationTestCase";
+    static final String TEST_CASE_METHOD_JUNIT_3 = "runMethod";
+    static final String TEST_CASE_CLASS_JUNIT_4 = "org.junit.runners.model.FrameworkMethod$1";
+    static final String TEST_CASE_METHOD_JUNIT_4 = "runReflectiveCall";
+    static final String TEST_CASE_CLASS_CUCUMBER_JVM = "cucumber.runtime.model.CucumberFeature";
+    static final String TEST_CASE_METHOD_CUCUMBER_JVM = "run";
+    private static final String EXTENSION = ".png";
+    private static final String TAG = "Spoon";
+    private static final Object LOCK = new Object();
+    private static final Pattern TAG_VALIDATION = Pattern.compile("[a-zA-Z0-9_-]+");
 
-  /** Holds a set of directories that have been cleared for this test */
-  private static Set<String> clearedOutputDirectories = new HashSet<String>();
+    /**
+     * Holds a set of directories that have been cleared for this test
+     */
+    private static Set<String> clearedOutputDirectories = new HashSet<String>();
 
-  /**
-   * Take a screenshot with the specified tag.
-   *
-   * @param activity Activity with which to capture a screenshot.
-   * @param tag Unique tag to further identify the screenshot. Must match [a-zA-Z0-9_-]+.
-   * @return the image file that was created
-   */
-  public static File screenshot(Activity activity, String tag) {
-    StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
-    String className = testClass.getClassName().replaceAll("[^A-Za-z0-9._-]", "_");
-    String methodName = testClass.getMethodName();
-    return screenshot(activity, tag, className, methodName);
-  }
-
-  /**
-   * Take a screenshot with the specified tag.  This version allows the caller to manually specify
-   * the test class name and method name.  This is necessary when the screenshot is not called in
-   * the traditional manner.
-   *
-   * @param activity Activity with which to capture a screenshot.
-   * @param tag Unique tag to further identify the screenshot. Must match [a-zA-Z0-9_-]+.
-   * @return the image file that was created
-   */
-  public static File screenshot(Activity activity, String tag, String testClassName,
-      String testMethodName) {
-    if (!TAG_VALIDATION.matcher(tag).matches()) {
-      throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
+    /**
+     * Take a screenshot with the specified tag.
+     *
+     * @param activity Activity with which to capture a screenshot.
+     * @param tag      Unique tag to further identify the screenshot. Must match [a-zA-Z0-9_-]+.
+     * @return the image file that was created
+     */
+    public static File screenshot(Activity activity, String tag) {
+        StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
+        String className = testClass.getClassName().replaceAll("[^A-Za-z0-9._-]", "_");
+        String methodName = testClass.getMethodName();
+        return screenshot(activity, tag, className, methodName);
     }
-    try {
-      File screenshotDirectory =
-          obtainScreenshotDirectory(activity.getApplicationContext(), testClassName,
-              testMethodName);
-      String screenshotName = System.currentTimeMillis() + NAME_SEPARATOR + tag + EXTENSION;
-      File screenshotFile = new File(screenshotDirectory, screenshotName);
-      takeScreenshot(screenshotFile, activity);
-      Log.d(TAG, "Captured screenshot '" + tag + "'.");
-      return screenshotFile;
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to capture screenshot.", e);
+
+    /**
+     * Take a screenshot with the specified tag.  This version allows the caller to manually specify
+     * the test class name and method name.  This is necessary when the screenshot is not called in
+     * the traditional manner.
+     *
+     * @param activity Activity with which to capture a screenshot.
+     * @param tag      Unique tag to further identify the screenshot. Must match [a-zA-Z0-9_-]+.
+     * @return the image file that was created
+     */
+    public static File screenshot(Activity activity, String tag, String testClassName,
+                                  String testMethodName) {
+        if (!TAG_VALIDATION.matcher(tag).matches()) {
+            throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
+        }
+        try {
+            File screenshotDirectory =
+                    obtainScreenshotDirectory(activity.getApplicationContext(), testClassName,
+                            testMethodName);
+            String screenshotName = System.currentTimeMillis() + NAME_SEPARATOR + tag + EXTENSION;
+            File screenshotFile = new File(screenshotDirectory, screenshotName);
+            takeScreenshot(screenshotFile, activity);
+            Log.d(TAG, "Captured screenshot '" + tag + "'.");
+            return screenshotFile;
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to capture screenshot.", e);
+        }
     }
-  }
 
-  private static void takeScreenshot(File file, final Activity activity) throws IOException {
-    View view = activity.getWindow().getDecorView();
-    final Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), ARGB_8888);
+    private static void takeScreenshot(File file, final Activity activity) throws IOException {
+        View view = activity.getWindow().getDecorView();
+        final Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), ARGB_8888);
 
-    if (Looper.myLooper() == Looper.getMainLooper()) {
-      // On main thread already, Just Do It™.
-      drawDecorViewToBitmap(activity, bitmap);
-    } else {
-      // On a background thread, post to main.
-      final CountDownLatch latch = new CountDownLatch(1);
-      activity.runOnUiThread(new Runnable() {
-        @Override public void run() {
-          try {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            // On main thread already, Just Do It™.
             drawDecorViewToBitmap(activity, bitmap);
-          } finally {
-            latch.countDown();
-          }
+        } else {
+            // On a background thread, post to main.
+            final CountDownLatch latch = new CountDownLatch(1);
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        drawDecorViewToBitmap(activity, bitmap);
+                    } finally {
+                        latch.countDown();
+                    }
+                }
+            });
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                String msg = "Unable to get screenshot " + file.getAbsolutePath();
+                Log.e(TAG, msg, e);
+                throw new RuntimeException(msg, e);
+            }
         }
-      });
-      try {
-        latch.await();
-      } catch (InterruptedException e) {
-        String msg = "Unable to get screenshot " + file.getAbsolutePath();
-        Log.e(TAG, msg, e);
-        throw new RuntimeException(msg, e);
-      }
-    }
 
-    OutputStream fos = null;
-    try {
-      fos = new BufferedOutputStream(new FileOutputStream(file));
-      bitmap.compress(PNG, 100 /* quality */, fos);
+        OutputStream fos = null;
+        try {
+            fos = new BufferedOutputStream(new FileOutputStream(file));
+            bitmap.compress(PNG, 100 /* quality */, fos);
 
-      chmodPlusR(file);
-    } finally {
-      bitmap.recycle();
-      if (fos != null) {
-        fos.close();
-      }
-    }
-  }
-
-  private static void drawDecorViewToBitmap(Activity activity, Bitmap bitmap) {
-    Canvas canvas = new Canvas(bitmap);
-    activity.getWindow().getDecorView().draw(canvas);
-  }
-
-  private static File obtainScreenshotDirectory(Context context, String testClassName,
-      String testMethodName) throws IllegalAccessException {
-    return filesDirectory(context, SPOON_SCREENSHOTS, testClassName, testMethodName);
-  }
-
-  /**
-   * Alternative to {@link #save(Context, File)}
-   * @param context Context used to access files.
-   * @param path Path to the file you want to save.
-   * @return the copy that was created.
-   */
-  public static File save(final Context context, final String path) {
-    return save(context, new File(path));
-  }
-
-  /**
-   * Save a file from this test run. The file will be saved under the current class & method.
-   * The file will be copied to, so make sure all the data you want have been
-   * written to the file before calling save.
-   *
-   * @param context Context used to access files.
-   * @param file The file to save.
-   * @return the copy that was created.
-   */
-  public static File save(final Context context, final File file) {
-    StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
-    String className = testClass.getClassName().replaceAll("[^A-Za-z0-9._-]", "_");
-    String methodName = testClass.getMethodName();
-    return save(context, className, methodName, file);
-  }
-
-  private static File save(Context context, String className, String methodName, File file) {
-    File filesDirectory = null;
-    try {
-      filesDirectory = filesDirectory(context, SPOON_FILES, className, methodName);
-      if (!file.exists()) {
-        throw new RuntimeException("Can't find any file at: " + file);
-      }
-
-      File target = new File(filesDirectory, file.getName());
-      copy(file, target);
-      Log.d(TAG, "Saved " + file);
-      return target;
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(("Unable to save file: " + file));
-    } catch (IOException e) {
-      throw new RuntimeException("Couldn't copy file " + file + " to " + filesDirectory);
-    }
-  }
-
-  private static void copy(File source, File target) throws IOException {
-    Log.d(TAG, "Will copy " + source + " to " + target);
-
-    target.createNewFile();
-    chmodPlusR(target);
-
-    final BufferedInputStream is = new BufferedInputStream(new FileInputStream(source));
-    final BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(target));
-    byte [] buffer = new byte[4096];
-    while (is.read(buffer) > 0) {
-      os.write(buffer);
-    }
-    is.close();
-    os.close();
-  }
-
-  private static File filesDirectory(Context context, String directoryType, String testClassName,
-      String testMethodName) throws IllegalAccessException {
-    File directory;
-    if (Build.VERSION.SDK_INT >=19) {
-      // Use external storage.
-      directory = new File(context.getExternalFilesDir(null), "app_" + directoryType);
-    } else {
-      // Use internal storage.
-      directory = context.getDir(directoryType, MODE_WORLD_READABLE);
-    }
-
-    synchronized (LOCK) {
-      if (!clearedOutputDirectories.contains(directoryType)) {
-        deletePath(directory, false);
-        clearedOutputDirectories.add(directoryType);
-      }
-    }
-
-    File dirClass = new File(directory, testClassName);
-    File dirMethod = new File(dirClass, testMethodName);
-    createDir(dirMethod);
-    return dirMethod;
-  }
-
-  /** Returns the test class element by looking at the method InstrumentationTestCase invokes. */
-  static StackTraceElement findTestClassTraceElement(StackTraceElement[] trace) {
-    for (int i = trace.length - 1; i >= 0; i--) {
-      StackTraceElement element = trace[i];
-      if (TEST_CASE_CLASS_JUNIT_3.equals(element.getClassName()) //
-          && TEST_CASE_METHOD_JUNIT_3.equals(element.getMethodName())) {
-        return extractStackElement(trace, i);
-      }
-
-      if (TEST_CASE_CLASS_JUNIT_4.equals(element.getClassName()) //
-          && TEST_CASE_METHOD_JUNIT_4.equals(element.getMethodName())) {
-        return extractStackElement(trace, i);
-      }
-      if (TEST_CASE_CLASS_CUCUMBER_JVM.equals(element.getClassName()) //
-              && TEST_CASE_METHOD_CUCUMBER_JVM.equals(element.getMethodName())) {
-        return extractStackElement(trace, i);
-      }
-    }
-
-    throw new IllegalArgumentException("Could not find test class!");
-  }
-
-  private static StackTraceElement extractStackElement(StackTraceElement[] trace, int i) {
-    //Stacktrace length changed in M
-    int testClassTraceIndex = Build.VERSION.SDK_INT >= 23 ? (i - 2) : (i - 3);
-    return trace[testClassTraceIndex];
-  }
-
-  private static void createDir(File dir) throws IllegalAccessException {
-    File parent = dir.getParentFile();
-    if (!parent.exists()) {
-      createDir(parent);
-    }
-    if (!dir.exists() && !dir.mkdirs()) {
-      throw new IllegalAccessException("Unable to create output dir: " + dir.getAbsolutePath());
-    }
-    chmodPlusRWX(dir);
-  }
-
-  private static void deletePath(File path, boolean inclusive) {
-    if (path.isDirectory()) {
-      File[] children = path.listFiles();
-      if (children != null) {
-        for (File child : children) {
-          deletePath(child, true);
+            chmodPlusR(file);
+        } finally {
+            bitmap.recycle();
+            if (fos != null) {
+                fos.close();
+            }
         }
-      }
     }
-    if (inclusive) {
-      path.delete();
-    }
-  }
 
-  private Spoon() {
-    // No instances.
-  }
+    private static void drawDecorViewToBitmap(Activity activity, Bitmap bitmap) {
+        Canvas canvas = new Canvas(bitmap);
+        activity.getWindow().getDecorView().draw(canvas);
+    }
+
+    private static File obtainScreenshotDirectory(Context context, String testClassName,
+                                                  String testMethodName) throws IllegalAccessException {
+        return filesDirectory(context, SPOON_SCREENSHOTS, testClassName, testMethodName);
+    }
+
+    /**
+     * Alternative to {@link #save(Context, File)}
+     *
+     * @param context Context used to access files.
+     * @param path    Path to the file you want to save.
+     * @return the copy that was created.
+     */
+    public static File save(final Context context, final String path) {
+        return save(context, new File(path));
+    }
+
+    /**
+     * Save a file from this test run. The file will be saved under the current class & method.
+     * The file will be copied to, so make sure all the data you want have been
+     * written to the file before calling save.
+     *
+     * @param context Context used to access files.
+     * @param file    The file to save.
+     * @return the copy that was created.
+     */
+    public static File save(final Context context, final File file) {
+        StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
+        String className = testClass.getClassName().replaceAll("[^A-Za-z0-9._-]", "_");
+        String methodName = testClass.getMethodName();
+        return save(context, className, methodName, file);
+    }
+
+    private static File save(Context context, String className, String methodName, File file) {
+        File filesDirectory = null;
+        try {
+            filesDirectory = filesDirectory(context, SPOON_FILES, className, methodName);
+            if (!file.exists()) {
+                throw new RuntimeException("Can't find any file at: " + file);
+            }
+
+            File target = new File(filesDirectory, file.getName());
+            copy(file, target);
+            Log.d(TAG, "Saved " + file);
+            return target;
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(("Unable to save file: " + file));
+        } catch (IOException e) {
+            throw new RuntimeException("Couldn't copy file " + file + " to " + filesDirectory);
+        }
+    }
+
+    private static void copy(File source, File target) throws IOException {
+        Log.d(TAG, "Will copy " + source + " to " + target);
+
+        target.createNewFile();
+        chmodPlusR(target);
+
+        final BufferedInputStream is = new BufferedInputStream(new FileInputStream(source));
+        final BufferedOutputStream os = new BufferedOutputStream(new FileOutputStream(target));
+        byte[] buffer = new byte[4096];
+        while (is.read(buffer) > 0) {
+            os.write(buffer);
+        }
+        is.close();
+        os.close();
+    }
+
+    private static File filesDirectory(Context context, String directoryType, String testClassName,
+                                       String testMethodName) throws IllegalAccessException {
+        File directory;
+        if (Build.VERSION.SDK_INT >= 19) {
+            // Use external storage.
+            directory = new File(context.getExternalFilesDir(null), "app_" + directoryType);
+        } else {
+            // Use internal storage.
+            directory = context.getDir(directoryType, MODE_WORLD_READABLE);
+        }
+
+        synchronized (LOCK) {
+            if (!clearedOutputDirectories.contains(directoryType)) {
+                deletePath(directory, false);
+                clearedOutputDirectories.add(directoryType);
+            }
+        }
+
+        File dirClass = new File(directory, testClassName);
+        File dirMethod = new File(dirClass, testMethodName);
+        createDir(dirMethod);
+        return dirMethod;
+    }
+
+    /**
+     * Returns the test class element by looking at the method InstrumentationTestCase invokes.
+     */
+    static StackTraceElement findTestClassTraceElement(StackTraceElement[] trace) {
+        for (int i = trace.length - 1; i >= 0; i--) {
+            StackTraceElement element = trace[i];
+            if (TEST_CASE_CLASS_JUNIT_3.equals(element.getClassName()) //
+                    && TEST_CASE_METHOD_JUNIT_3.equals(element.getMethodName())) {
+                return extractStackElement(trace, i);
+            }
+
+            if (TEST_CASE_CLASS_JUNIT_4.equals(element.getClassName()) //
+                    && TEST_CASE_METHOD_JUNIT_4.equals(element.getMethodName())) {
+                return extractStackElement(trace, i);
+            }
+            if (TEST_CASE_CLASS_CUCUMBER_JVM.equals(element.getClassName()) //
+                    && TEST_CASE_METHOD_CUCUMBER_JVM.equals(element.getMethodName())) {
+                return extractStackElement(trace, i);
+            }
+        }
+
+        throw new IllegalArgumentException("Could not find test class!");
+    }
+
+    private static StackTraceElement extractStackElement(StackTraceElement[] trace, int i) {
+        //Stacktrace length changed in M
+        int testClassTraceIndex = Build.VERSION.SDK_INT >= 23 ? (i - 2) : (i - 3);
+        return trace[testClassTraceIndex];
+    }
+
+    private static void createDir(File dir) throws IllegalAccessException {
+        File parent = dir.getParentFile();
+        if (!parent.exists()) {
+            createDir(parent);
+        }
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new IllegalAccessException("Unable to create output dir: " + dir.getAbsolutePath());
+        }
+        chmodPlusRWX(dir);
+    }
+
+    private static void deletePath(File path, boolean inclusive) {
+        if (path.isDirectory()) {
+            File[] children = path.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deletePath(child, true);
+                }
+            }
+        }
+        if (inclusive) {
+            path.delete();
+        }
+    }
+
+    private Spoon() {
+        // No instances.
+    }
 }

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -23,7 +23,6 @@ import java.util.regex.Pattern;
 import static android.content.Context.MODE_WORLD_READABLE;
 import static android.graphics.Bitmap.CompressFormat.PNG;
 import static android.graphics.Bitmap.Config.ARGB_8888;
-import static android.os.Environment.getExternalStorageDirectory;
 import static com.squareup.spoon.Chmod.chmodPlusR;
 import static com.squareup.spoon.Chmod.chmodPlusRWX;
 

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -206,7 +206,7 @@ public final class Spoon {
     File directory;
     if (Build.VERSION.SDK_INT >= 21) {
       // Use external storage.
-      directory = new File(getExternalStorageDirectory(), "app_" + directoryType);
+      directory = new File(context.getExternalFilesDir(null), "app_" + directoryType);
     } else {
       // Use internal storage.
       directory = context.getDir(directoryType, MODE_WORLD_READABLE);

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -203,7 +203,7 @@ public final class Spoon {
   private static File filesDirectory(Context context, String directoryType, String testClassName,
       String testMethodName) throws IllegalAccessException {
     File directory;
-    if (Build.VERSION.SDK_INT >= 21) {
+    if (Build.VERSION.SDK_INT >=19) {
       // Use external storage.
       directory = new File(context.getExternalFilesDir(null), "app_" + directoryType);
     } else {

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -58,7 +58,8 @@ public final class Spoon {
      * @return the image file that was created
      */
     public static File screenshot(Activity activity, String tag) {
-        StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
+        StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread()
+                .getStackTrace());
         String className = testClass.getClassName().replaceAll("[^A-Za-z0-9._-]", "_");
         String methodName = testClass.getMethodName();
         return screenshot(activity, tag, className, methodName);
@@ -141,7 +142,8 @@ public final class Spoon {
     }
 
     private static File obtainScreenshotDirectory(Context context, String testClassName,
-                                                  String testMethodName) throws IllegalAccessException {
+                                                  String testMethodName) throws
+            IllegalAccessException {
         return filesDirectory(context, SPOON_SCREENSHOTS, testClassName, testMethodName);
     }
 
@@ -166,7 +168,8 @@ public final class Spoon {
      * @return the copy that was created.
      */
     public static File save(final Context context, final File file) {
-        StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread().getStackTrace());
+        StackTraceElement testClass = findTestClassTraceElement(Thread.currentThread()
+                .getStackTrace());
         String className = testClass.getClassName().replaceAll("[^A-Za-z0-9._-]", "_");
         String methodName = testClass.getMethodName();
         return save(context, className, methodName, file);
@@ -267,7 +270,8 @@ public final class Spoon {
             createDir(parent);
         }
         if (!dir.exists() && !dir.mkdirs()) {
-            throw new IllegalAccessException("Unable to create output dir: " + dir.getAbsolutePath());
+            throw new IllegalAccessException("Unable to create output dir: " + dir
+                    .getAbsolutePath());
         }
         chmodPlusRWX(dir);
     }

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -192,24 +192,6 @@ public final class SpoonDeviceRunner {
       return result.markInstallAsFailed("Unable to install instrumentation APK.").build();
     }
 
-    // If this is Android Marshmallow or above grant WRITE_EXTERNAL_STORAGE
-    if (Integer.parseInt(device.getProperty(IDevice.PROP_BUILD_API_LEVEL)) >= 23) {
-      String appPackage = instrumentationInfo.getApplicationPackage();
-      try {
-        CollectingOutputReceiver grantOutputReceiver = new CollectingOutputReceiver();
-        device.executeShellCommand("pm grant " + appPackage
-            + " android.permission.READ_EXTERNAL_STORAGE", grantOutputReceiver);
-        device.executeShellCommand("pm grant " + appPackage
-            + " android.permission.WRITE_EXTERNAL_STORAGE", grantOutputReceiver);
-      } catch (Exception e) {
-        logInfo("Exception while granting external storage access to application apk"
-            + "on device [%s]", serial);
-        e.printStackTrace(System.out);
-        return result.markInstallAsFailed("Unable to grant external storage access to"
-            + " application APK.").build();
-      }
-    }
-
     // Create the output directory, if it does not already exist.
     work.mkdirs();
 


### PR DESCRIPTION
No need for storage permissions; use context.getExternalFilesDir instead to store screenshots.