### PR TITLE
Auto-sharding support with result merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,21 @@ Test Sharding
 
 The Android Instrumentation runner supports test sharding using the `numShards` and `shardIndex` arguments ([documentation](https://developer.android.com/tools/testing-support-library/index.html#ajur-sharding)).  
 
-You can use the `--e` option with Spoon to pass those arguments through to the instrumentation runner, e.g.
+If you are specifying serials for multiple devices, you may use spoon's built in auto-sharding by specifying --shard:
+
+```
+java -jar spoon-runner-1.3.1-jar-with-dependencies.jar \
+    --apk ExampleApp-debug.apk \
+    --test-apk ExampleApp-debug-androidTest-unaligned.apk \
+    -serial emulator-1 \
+    -serial emulator-2 \
+    --shard
+```
+
+This will automatically shard across all specified serials, and merge the results.
+
+If you'd like to use a different sharding strategy, you can use the `--e` option with Spoon to pass those arguments through to the instrumentation runner, e.g.
+
 ```
 java -jar spoon-runner-1.3.1-jar-with-dependencies.jar \
     --apk ExampleApp-debug.apk \
@@ -192,6 +206,9 @@ java -jar spoon-runner-1.3.1-jar-with-dependencies.jar \
     --e numShards=4 \
     --e shardIndex=0
 ```
+However, it will be up to you to merge the output from the shards.
+
+
 If you use Jenkins, a good way to set up sharding is inside a "Multi-configuration project".
 
  - Add a "User-defined Axis".  Choose a name for the shard index variable, and define the index values you want (starting at zero).

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -55,6 +55,8 @@ public final class SpoonDeviceRunner {
   private final File apk;
   private final File testApk;
   private final String serial;
+  private final int shardIndex;
+  private final int numShards;
   private final boolean debug;
   private final boolean noAnimations;
   private final int adbTimeout;
@@ -87,8 +89,8 @@ public final class SpoonDeviceRunner {
    *        {@code className}.
    * @param testRunListeners Additional TestRunListener or empty list.
    */
-  SpoonDeviceRunner(File sdk, File apk, File testApk, File output, String serial, boolean debug,
-      boolean noAnimations, int adbTimeout, String classpath,
+  SpoonDeviceRunner(File sdk, File apk, File testApk, File output, String serial, int shardIndex,
+      int numShards, boolean debug, boolean noAnimations, int adbTimeout, String classpath,
       SpoonInstrumentationInfo instrumentationInfo, List<String> instrumentationArgs,
       String className, String methodName, IRemoteAndroidTestRunner.TestSize testSize,
       List<ITestRunListener> testRunListeners) {
@@ -96,6 +98,8 @@ public final class SpoonDeviceRunner {
     this.apk = apk;
     this.testApk = testApk;
     this.serial = serial;
+    this.shardIndex = shardIndex;
+    this.numShards = numShards;
     this.debug = debug;
     this.noAnimations = noAnimations;
     this.adbTimeout = adbTimeout;
@@ -237,6 +241,12 @@ public final class SpoonDeviceRunner {
           runner.addInstrumentationArg(key, value);
         }
       }
+      // Add the sharding instrumentation arguments if necessary
+      if (numShards != 0 && shardIndex != 0) {
+        runner.addInstrumentationArg("numShards", Integer.toString(numShards));
+        runner.addInstrumentationArg("shardIndex", Integer.toString(numShards));
+      }
+
 
       if (!isNullOrEmpty(className)) {
         if (isNullOrEmpty(methodName)) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -64,11 +64,11 @@ public final class SpoonRunner {
   private File initScript;
 
   private SpoonRunner(String title, File androidSdk, File applicationApk, File instrumentationApk,
-      File output, boolean debug, boolean noAnimations, int adbTimeoutMillis, Set<String> serials, boolean shard,
-      String classpath, List<String> instrumentationArgs, String className, String methodName,
-      IRemoteAndroidTestRunner.TestSize testSize, boolean failIfNoDeviceConnected,
-      List<ITestRunListener> testRunListeners, boolean sequential, File initScript,
-      boolean terminateAdb) {
+      File output, boolean debug, boolean noAnimations, int adbTimeoutMillis, Set<String> serials,
+      boolean shard, String classpath, List<String> instrumentationArgs, String className,
+      String methodName, IRemoteAndroidTestRunner.TestSize testSize,
+      boolean failIfNoDeviceConnected, List<ITestRunListener> testRunListeners, boolean sequential,
+      File initScript, boolean terminateAdb) {
     this.title = title;
     this.androidSdk = androidSdk;
     this.applicationApk = applicationApk;
@@ -182,13 +182,14 @@ public final class SpoonRunner {
         logDebug(debug, "[%s] Starting execution.", serial);
         if (shard) {
           shardIndex++;
-          logDebug(debug, "shardIndex [%i]", shardIndex);
+          logDebug(debug, "shardIndex [%d]", shardIndex);
         }
         final int safeShardIndex = shardIndex;
         Runnable runnable = new Runnable() {
           @Override public void run() {
             try {
-              summary.addResult(safeSerial, getTestRunner(serial, safeShardIndex, numShards, testInfo).runInNewProcess());
+              summary.addResult(safeSerial,
+                  getTestRunner(serial, safeShardIndex, numShards, testInfo).runInNewProcess());
             } catch (Exception e) {
               e.printStackTrace(System.out);
               summary.addResult(safeSerial, new DeviceResult.Builder().addException(e).build());
@@ -278,7 +279,8 @@ public final class SpoonRunner {
     return true;
   }
 
-  private SpoonDeviceRunner getTestRunner(String serial, int shardIndex, int numShards, SpoonInstrumentationInfo testInfo) {
+  private SpoonDeviceRunner getTestRunner(String serial, int shardIndex, int numShards,
+      SpoonInstrumentationInfo testInfo) {
     return new SpoonDeviceRunner(androidSdk, applicationApk, instrumentationApk, output, serial,
             shardIndex, numShards, debug, noAnimations, adbTimeoutMillis, classpath, testInfo,
             instrumentationArgs, className, methodName, testSize, testRunListeners);
@@ -542,7 +544,8 @@ public final class SpoonRunner {
         description = "Serial of the device to use (May be used multiple times)")
     private List<String> serials = new ArrayList<String>();
 
-    @Parameter(names = { "--shard"} )
+    @Parameter(names = { "--shard" },
+        description = "Automatically shard across all specified serials") //
     public boolean shard;
 
     @Parameter(names = { "--debug" }, hidden = true) //

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -55,6 +55,7 @@ public final class SpoonRunner {
   private final String className;
   private final String methodName;
   private final Set<String> serials;
+  private final boolean shard;
   private final String classpath;
   private final IRemoteAndroidTestRunner.TestSize testSize;
   private final boolean failIfNoDeviceConnected;
@@ -63,7 +64,7 @@ public final class SpoonRunner {
   private File initScript;
 
   private SpoonRunner(String title, File androidSdk, File applicationApk, File instrumentationApk,
-      File output, boolean debug, boolean noAnimations, int adbTimeoutMillis, Set<String> serials,
+      File output, boolean debug, boolean noAnimations, int adbTimeoutMillis, Set<String> serials, boolean shard,
       String classpath, List<String> instrumentationArgs, String className, String methodName,
       IRemoteAndroidTestRunner.TestSize testSize, boolean failIfNoDeviceConnected,
       List<ITestRunListener> testRunListeners, boolean sequential, File initScript,
@@ -82,6 +83,7 @@ public final class SpoonRunner {
     this.classpath = classpath;
     this.testSize = testSize;
     this.serials = ImmutableSet.copyOf(serials);
+    this.shard = shard;
     this.failIfNoDeviceConnected = failIfNoDeviceConnected;
     this.testRunListeners = testRunListeners;
     this.terminateAdb = terminateAdb;
@@ -157,7 +159,7 @@ public final class SpoonRunner {
       String safeSerial = SpoonUtils.sanitizeSerial(serial);
       try {
         logDebug(debug, "[%s] Starting execution.", serial);
-        summary.addResult(safeSerial, getTestRunner(serial, testInfo).run(adb));
+        summary.addResult(safeSerial, getTestRunner(serial, 0, 0, testInfo).run(adb));
       } catch (Exception e) {
         logDebug(debug, "[%s] Execution exception!", serial);
         e.printStackTrace(System.out);
@@ -172,13 +174,21 @@ public final class SpoonRunner {
       // Spawn a new thread for each device and wait for them all to finish.
       final CountDownLatch done = new CountDownLatch(targetCount);
       final Set<String> remaining = synchronizedSet(new HashSet<String>(serials));
+
+      int shardIndex = 0;
+      final int numShards = shard ? serials.size() : 0;
       for (final String serial : serials) {
         final String safeSerial = SpoonUtils.sanitizeSerial(serial);
         logDebug(debug, "[%s] Starting execution.", serial);
+        if (shard) {
+          shardIndex++;
+          logDebug(debug, "shardIndex [%i]", shardIndex);
+        }
+        final int safeShardIndex = shardIndex;
         Runnable runnable = new Runnable() {
           @Override public void run() {
             try {
-              summary.addResult(safeSerial, getTestRunner(serial, testInfo).runInNewProcess());
+              summary.addResult(safeSerial, getTestRunner(serial, safeShardIndex, numShards, testInfo).runInNewProcess());
             } catch (Exception e) {
               e.printStackTrace(System.out);
               summary.addResult(safeSerial, new DeviceResult.Builder().addException(e).build());
@@ -268,10 +278,10 @@ public final class SpoonRunner {
     return true;
   }
 
-  private SpoonDeviceRunner getTestRunner(String serial, SpoonInstrumentationInfo testInfo) {
+  private SpoonDeviceRunner getTestRunner(String serial, int shardIndex, int numShards, SpoonInstrumentationInfo testInfo) {
     return new SpoonDeviceRunner(androidSdk, applicationApk, instrumentationApk, output, serial,
-        debug, noAnimations, adbTimeoutMillis, classpath, testInfo, instrumentationArgs, className,
-        methodName, testSize, testRunListeners);
+            shardIndex, numShards, debug, noAnimations, adbTimeoutMillis, classpath, testInfo,
+            instrumentationArgs, className, methodName, testSize, testRunListeners);
   }
 
   /** Build a test suite for the specified devices and configuration. */
@@ -295,6 +305,7 @@ public final class SpoonRunner {
     private boolean sequential;
     private File initScript;
     private boolean terminateAdb = true;
+    private boolean shard = false;
 
     /** Identifying title for this execution. */
     public Builder setTitle(String title) {
@@ -421,6 +432,11 @@ public final class SpoonRunner {
       return this;
     }
 
+    public Builder setShard(boolean shard) {
+      this.shard = shard;
+      return this;
+    }
+
     public Builder addTestRunListener(ITestRunListener testRunListener) {
       checkNotNull(testRunListener, "TestRunListener cannot be null.");
       testRunListeners.add(testRunListener);
@@ -445,7 +461,7 @@ public final class SpoonRunner {
       }
 
       return new SpoonRunner(title, androidSdk, applicationApk, instrumentationApk, output, debug,
-          noAnimations, adbTimeoutMillis, serials, classpath, instrumentationArgs, className,
+          noAnimations, adbTimeoutMillis, serials, shard, classpath, instrumentationArgs, className,
           methodName, testSize, failIfNoDeviceConnected, testRunListeners, sequential, initScript,
           terminateAdb);
     }
@@ -526,6 +542,9 @@ public final class SpoonRunner {
         description = "Serial of the device to use (May be used multiple times)")
     private List<String> serials = new ArrayList<String>();
 
+    @Parameter(names = { "--shard"} )
+    public boolean shard;
+
     @Parameter(names = { "--debug" }, hidden = true) //
     public boolean debug;
 
@@ -591,7 +610,8 @@ public final class SpoonRunner {
         .setInitScript(parsedArgs.initScript)
         .setInstrumentationArgs(parsedArgs.instrumentationArgs)
         .setClassName(parsedArgs.className)
-        .setMethodName(parsedArgs.methodName);
+        .setMethodName(parsedArgs.methodName)
+        .setShard(parsedArgs.shard);
 
     if (parsedArgs.serials == null || parsedArgs.serials.isEmpty()) {
       builder.useAllAttachedDevices();


### PR DESCRIPTION
This adds an option to spoon, --shard, which will run tests in sharded mode across all available serials.  The benefit of this is that the results will be merged into a single index.html, instead of requiring the user to merge their own results.

```
java -jar spoon-runner-1.3.1-jar-with-dependencies.jar \
    --apk ExampleApp-debug.apk \
    --test-apk ExampleApp-debug-androidTest-unaligned.apk \
    -serial emulator-1 \
    -serial emulator-2 \
    --shard
```

This will automatically shard across all specified serials, and merge the results.  Here is an example of the outputted index.html

![screenshot from 2016-04-08 13 50 36](https://cloud.githubusercontent.com/assets/4722184/14397280/60639b0c-fd91-11e5-8be0-73740933d03e.png)
