### PR TITLE
code coverage option for spoon plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Options:
     --size              Only run test methods annotated by testSize (small, medium, large)
     --adb-timeout       Set maximum execution time per test in seconds (10min default)
     --fail-on-failure   Non-zero exit code on failure
+    --coverage          Code coverage flag
     --fail-if-no-device-connected Fail if no device is connected
     --sequential        Execute the tests device by device
     --init-script       Path to a script that you want to run before each device

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -13,9 +13,6 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.squareup.spoon.adapters.TestIdentifierAdapter;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.TrueFileFilter;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -28,6 +25,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 
 import static com.android.ddmlib.FileListingService.FileEntry;
 import static com.android.ddmlib.SyncService.getNullProgressMonitor;

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -57,6 +57,7 @@ public final class SpoonRunner {
   private final Set<String> serials;
   private final String classpath;
   private final IRemoteAndroidTestRunner.TestSize testSize;
+  private boolean codeCoverage;
   private final boolean failIfNoDeviceConnected;
   private final List<ITestRunListener> testRunListeners;
   private final boolean terminateAdb;
@@ -67,7 +68,7 @@ public final class SpoonRunner {
       String classpath, List<String> instrumentationArgs, String className, String methodName,
       IRemoteAndroidTestRunner.TestSize testSize, boolean failIfNoDeviceConnected,
       List<ITestRunListener> testRunListeners, boolean sequential, File initScript,
-      boolean terminateAdb) {
+      boolean terminateAdb, boolean codeCoverage) {
     this.title = title;
     this.androidSdk = androidSdk;
     this.applicationApk = applicationApk;
@@ -81,6 +82,7 @@ public final class SpoonRunner {
     this.methodName = methodName;
     this.classpath = classpath;
     this.testSize = testSize;
+    this.codeCoverage = codeCoverage;
     this.serials = ImmutableSet.copyOf(serials);
     this.failIfNoDeviceConnected = failIfNoDeviceConnected;
     this.testRunListeners = testRunListeners;
@@ -271,7 +273,7 @@ public final class SpoonRunner {
   private SpoonDeviceRunner getTestRunner(String serial, SpoonInstrumentationInfo testInfo) {
     return new SpoonDeviceRunner(androidSdk, applicationApk, instrumentationApk, output, serial,
         debug, noAnimations, adbTimeoutMillis, classpath, testInfo, instrumentationArgs, className,
-        methodName, testSize, testRunListeners);
+        methodName, testSize, testRunListeners, codeCoverage);
   }
 
   /** Build a test suite for the specified devices and configuration. */
@@ -295,6 +297,7 @@ public final class SpoonRunner {
     private boolean sequential;
     private File initScript;
     private boolean terminateAdb = true;
+    private boolean codeCoverage;
 
     /** Identifying title for this execution. */
     public Builder setTitle(String title) {
@@ -421,6 +424,11 @@ public final class SpoonRunner {
       return this;
     }
 
+    public Builder setCodeCoverage(boolean codeCoverage) {
+      this.codeCoverage = codeCoverage;
+      return this;
+    }
+
     public Builder addTestRunListener(ITestRunListener testRunListener) {
       checkNotNull(testRunListener, "TestRunListener cannot be null.");
       testRunListeners.add(testRunListener);
@@ -447,7 +455,7 @@ public final class SpoonRunner {
       return new SpoonRunner(title, androidSdk, applicationApk, instrumentationApk, output, debug,
           noAnimations, adbTimeoutMillis, serials, classpath, instrumentationArgs, className,
           methodName, testSize, failIfNoDeviceConnected, testRunListeners, sequential, initScript,
-          terminateAdb);
+          terminateAdb, codeCoverage);
     }
   }
 
@@ -529,6 +537,9 @@ public final class SpoonRunner {
     @Parameter(names = { "--debug" }, hidden = true) //
     public boolean debug;
 
+    @Parameter(names = { "--coverage" }, description = "Code coverage flag", arity = 1)
+    public Boolean codeCoverage = false;
+
     @Parameter(names = { "-h", "--help" }, description = "Command help", help = true, hidden = true)
     public boolean help;
   }
@@ -590,6 +601,7 @@ public final class SpoonRunner {
         .setSequential(parsedArgs.sequential)
         .setInitScript(parsedArgs.initScript)
         .setInstrumentationArgs(parsedArgs.instrumentationArgs)
+        .setCodeCoverage(parsedArgs.codeCoverage)
         .setClassName(parsedArgs.className)
         .setMethodName(parsedArgs.methodName);
 


### PR DESCRIPTION
this option will enable the user to pass coverage flag as ` --coverage true` to spoon-runner in order to calculate code coverage. Once tests are finished, it will automatically pull the `coverage.ec` file from device to `{spoon output directory}/coverage` directory