### PR TITLE
Make devices responsible for their own testcount

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlIndex.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlIndex.java
@@ -80,7 +80,6 @@ final class HtmlIndex {
       String name = (details != null) ? details.getName() : serial;
       boolean executionFailed = testResults.isEmpty() && !result.getExceptions().isEmpty();
       return new Device(serial, name, testResults, executionFailed);
-
     }
 
     public final String serial;

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlIndex.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlIndex.java
@@ -57,18 +57,16 @@ final class HtmlIndex {
     }
     subtitle.append(" at ").append(started);
 
-    return new HtmlIndex(summary.getTitle(), subtitle.toString(), tests.size(), devices);
+    return new HtmlIndex(summary.getTitle(), subtitle.toString(),  devices);
   }
 
   public final String title;
   public final String subtitle;
-  public final int testCount;
   public final List<Device> devices;
 
-  HtmlIndex(String title, String subtitle, int testCount, List<Device> devices) {
+  HtmlIndex(String title, String subtitle, List<Device> devices) {
     this.title = title;
     this.subtitle = subtitle;
-    this.testCount = testCount;
     this.devices = devices;
   }
 
@@ -82,17 +80,20 @@ final class HtmlIndex {
       String name = (details != null) ? details.getName() : serial;
       boolean executionFailed = testResults.isEmpty() && !result.getExceptions().isEmpty();
       return new Device(serial, name, testResults, executionFailed);
+
     }
 
     public final String serial;
     public final String name;
     public final List<TestResult> testResults;
     public final boolean executionFailed;
+    public final int testCount;
 
     Device(String serial, String name, List<TestResult> testResults, boolean executionFailed) {
       this.serial = serial;
       this.name = name;
       this.testResults = testResults;
+      this.testCount = testResults.size();
       this.executionFailed = executionFailed;
     }
 


### PR DESCRIPTION
Now that sharding is fixed, test output was pretty ugly, because colspan=testCount, and testCount is the entire number of tests, where the shards only a subset.  So, our output for 630 tests looks like this:

![screen shot 2016-04-27 at 3 23 45 pm](https://cloud.githubusercontent.com/assets/4722184/14871537/eb2bcc9a-0c97-11e6-85bb-cadfe7a75bae.png)

The template was already setup to use per-device testCounts, I just had to move them from the scope of the index file to the scope of each device.  

Here's a before and after the change on a smaller set of tests

BEFORE:

![screenshot from 2016-04-27 16 41 33](https://cloud.githubusercontent.com/assets/4722184/14871508/af35e8b0-0c97-11e6-987a-cde6cec2ecb3.png)

AFTER:

![screenshot from 2016-04-27 16 41 46](https://cloud.githubusercontent.com/assets/4722184/14871511/bcb6897c-0c97-11e6-8e38-7b25d638111a.png)

I also tested when the device has an exception, and it still looks good:

![screenshot from 2016-04-27 16 43 56](https://cloud.githubusercontent.com/assets/4722184/14871519/cb80aad2-0c97-11e6-9c02-d12e6b77b6b5.png)

