### PR TITLE
Add debug logging for when instrumentationArg is not processed

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -239,12 +239,14 @@ public final class SpoonDeviceRunner {
           int firstEqualSignIndex = pair.indexOf("=");
           if (firstEqualSignIndex <= -1) {
             //No Equal Sign, can't process
+            logDebug(debug, "Can't process instrumentationArg [%s] (no equal sign)", pair);
             continue;
           }
           String key = pair.substring(0, firstEqualSignIndex);
           String value = pair.substring(firstEqualSignIndex + 1);
           if (isNullOrEmpty(key) || isNullOrEmpty(value)) {
             //invalid values, skipping
+            logDebug(debug, "Can't process instrumentationArg [%s] (empty key or value)", pair);
             continue;
           }
           runner.addInstrumentationArg(key, value);


### PR DESCRIPTION
Took me a second to realize that my a new instrumentation arg i was using wasn't being processed since I didn't use "=".  Figure there should be at least some debug logging alerting the user when this happens.