### PR TITLE
Merging multiple coverage files into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Options:
     --size              Only run test methods annotated by testSize (small, medium, large)
     --adb-timeout       Set maximum execution time per test in seconds (10min default)
     --fail-on-failure   Non-zero exit code on failure
-    --coverage          Code coverage flag
+    --coverage          Code coverage flag (This option pulls the coverage file from all devices and merge them into a single file `merged-coverage.ec`.)
     --fail-if-no-device-connected Fail if no device is connected
     --sequential        Execute the tests device by device
     --init-script       Path to a script that you want to run before each device
@@ -196,7 +196,7 @@ java -jar spoon-runner-1.3.1-jar-with-dependencies.jar \
     --shard
 ```
 
-This will automatically shard across all specified serials, and merge the results.
+This will automatically shard across all specified serials, and merge the results. When this option is running with `--coverage` flag. It will merge all the coverage files generated from all devices into a single file called `merged-coverage.ec`.
 
 If you'd like to use a different sharding strategy, you can use the `--e` option with Spoon to pass those arguments through to the instrumentation runner, e.g.
 

--- a/spoon-runner/pom.xml
+++ b/spoon-runner/pom.xml
@@ -55,6 +55,11 @@
       <groupId>org.lesscss</groupId>
       <artifactId>lesscss</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>jacoco-maven-plugin</artifactId>
+      <version>0.7.4.201502262128</version>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/spoon-runner/pom.xml
+++ b/spoon-runner/pom.xml
@@ -59,6 +59,12 @@
       <groupId>org.jacoco</groupId>
       <artifactId>jacoco-maven-plugin</artifactId>
       <version>0.7.4.201502262128</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-project</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
@@ -13,7 +13,7 @@ import static com.squareup.spoon.SpoonDeviceRunner.COVERAGE_DIR;
 import static com.squareup.spoon.SpoonDeviceRunner.COVERAGE_FILE;
 import static com.squareup.spoon.SpoonUtils.sanitizeSerial;
 
-public class SpoonCoverageMerger {
+final class SpoonCoverageMerger {
   private static final String MERGED_COVERAGE_FILE = "merged-coverage.ec";
   private ExecFileLoader execFileLoader;
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
@@ -1,0 +1,42 @@
+package com.squareup.spoon;
+
+import com.google.common.base.Function;
+import org.jacoco.core.tools.ExecFileLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.google.common.collect.Collections2.transform;
+import static com.squareup.spoon.SpoonDeviceRunner.COVERAGE_DIR;
+import static com.squareup.spoon.SpoonDeviceRunner.COVERAGE_FILE;
+import static com.squareup.spoon.SpoonUtils.sanitizeSerial;
+
+public class SpoonCoverageMerger {
+  private static final String MERGED_COVERAGE_FILE = "merged-coverage.ec";
+  private ExecFileLoader execFileLoader;
+
+  public SpoonCoverageMerger(ExecFileLoader execFileLoader) {
+    this.execFileLoader = execFileLoader;
+  }
+
+  public void mergeCoverageFiles(Set<String> serials, File outputDirectory) throws IOException {
+    Collection<String> sanitizeSerials = transform(serials, toSanitizeSerials());
+    for (String serial : sanitizeSerials) {
+      String coverageFilePath = COVERAGE_DIR + "/" + serial + "/" + COVERAGE_FILE;
+      execFileLoader.load(new File(outputDirectory, coverageFilePath));
+    }
+    String mergedCoverageFile = COVERAGE_DIR + "/" + MERGED_COVERAGE_FILE;
+    execFileLoader.save(new File(outputDirectory, mergedCoverageFile), false);
+  }
+
+  private Function<String, String> toSanitizeSerials() {
+    return new Function<String, String>() {
+      @Override
+      public String apply(String serials) {
+        return sanitizeSerial(serials);
+      }
+    };
+  }
+}

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
@@ -17,8 +17,8 @@ final class SpoonCoverageMerger {
   private static final String MERGED_COVERAGE_FILE = "merged-coverage.ec";
   private ExecFileLoader execFileLoader;
 
-  public SpoonCoverageMerger(ExecFileLoader execFileLoader) {
-    this.execFileLoader = execFileLoader;
+  public SpoonCoverageMerger() {
+    this.execFileLoader = new ExecFileLoader();
   }
 
   public void mergeCoverageFiles(Set<String> serials, File outputDirectory) throws IOException {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -44,7 +44,6 @@ import static com.squareup.spoon.SpoonUtils.obtainRealDevice;
 public final class SpoonDeviceRunner {
   private static final String FILE_EXECUTION = "execution.json";
   private static final String FILE_RESULT = "result.json";
-  private static final String COVERAGE_FILE = "coverage.ec";
   private static final String DEVICE_SCREENSHOT_DIR = "app_" + SPOON_SCREENSHOTS;
   private static final String DEVICE_FILE_DIR = "app_" + SPOON_FILES;
   private static final String[] DEVICE_DIRS = {DEVICE_SCREENSHOT_DIR, DEVICE_FILE_DIR};
@@ -52,6 +51,7 @@ public final class SpoonDeviceRunner {
   static final String JUNIT_DIR = "junit-reports";
   static final String IMAGE_DIR = "image";
   static final String FILE_DIR = "file";
+  static final String COVERAGE_FILE = "coverage.ec";
   static final String COVERAGE_DIR = "coverage";
 
   private final File sdk;

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -12,6 +12,7 @@ import com.google.common.collect.ImmutableSet;
 import com.squareup.spoon.html.HtmlRenderer;
 
 import org.apache.commons.io.FileUtils;
+import org.jacoco.core.tools.ExecFileLoader;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -216,6 +217,15 @@ public final class SpoonRunner {
       }
     }
 
+    if (codeCoverage) {
+      SpoonCoverageMerger coverageMerger = new SpoonCoverageMerger(new ExecFileLoader());
+      try {
+        coverageMerger.mergeCoverageFiles(serials, output);
+        logDebug(debug, "Merging of coverage files done.");
+      } catch (IOException e) {
+        throw new RuntimeException("error while merging coverage files");
+      }
+    }
     if (!debug) {
       // Clean up anything in the work directory.
       try {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -222,8 +222,8 @@ public final class SpoonRunner {
       try {
         coverageMerger.mergeCoverageFiles(serials, output);
         logDebug(debug, "Merging of coverage files done.");
-      } catch (IOException e) {
-        throw new RuntimeException("error while merging coverage files");
+      } catch (IOException exception) {
+        throw new RuntimeException("error while merging coverage files", exception);
       }
     }
     if (!debug) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -10,9 +10,7 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.converters.IParameterSplitter;
 import com.google.common.collect.ImmutableSet;
 import com.squareup.spoon.html.HtmlRenderer;
-
 import org.apache.commons.io.FileUtils;
-import org.jacoco.core.tools.ExecFileLoader;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -218,7 +216,7 @@ public final class SpoonRunner {
     }
 
     if (codeCoverage) {
-      SpoonCoverageMerger coverageMerger = new SpoonCoverageMerger(new ExecFileLoader());
+      SpoonCoverageMerger coverageMerger = new SpoonCoverageMerger();
       try {
         coverageMerger.mergeCoverageFiles(serials, output);
         logDebug(debug, "Merging of coverage files done.");

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.java
@@ -7,10 +7,8 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.io.File;
-import java.util.HashSet;
 import java.util.Set;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.argThat;

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.java
@@ -1,0 +1,58 @@
+package com.squareup.spoon;
+
+import org.hamcrest.CustomTypeSafeMatcher;
+import org.jacoco.core.tools.ExecFileLoader;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.File;
+import java.util.HashSet;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class SpoonCoverageMergerTest {
+
+  @Test
+  public void shouldMergeCoverageFiles() throws Exception {
+    ExecFileLoader execFileLoader = mock(ExecFileLoader.class);
+    HashSet<String> serials = new HashSet<String>(asList("10.0.0.1:1234", "10.0.0.2:1234"));
+    File spoonOutputDirectory = new File("/output");
+
+    SpoonCoverageMerger spoonCoverageMerger = new SpoonCoverageMerger(execFileLoader);
+
+    spoonCoverageMerger.mergeCoverageFiles(serials, spoonOutputDirectory);
+
+    ArgumentCaptor<File> captor = ArgumentCaptor.forClass(File.class);
+    verify(execFileLoader, times(2)).load(captor.capture());
+    assertThat(captor.getAllValues().get(0), coverageFileOf("10.0.0.1:1234"));
+    assertThat(captor.getAllValues().get(1), coverageFileOf("10.0.0.2:1234"));
+
+    verify(execFileLoader, times(1)).save(argThat(hasPath("/output/coverage/merged-coverage.ec")), eq(false));
+  }
+
+  private CustomTypeSafeMatcher<File> hasPath(final String path) {
+    return new CustomTypeSafeMatcher<File>("") {
+      @Override
+      protected boolean matchesSafely(File file) {
+        return file.getPath().equals(path);
+      }
+    };
+  }
+
+  private CustomTypeSafeMatcher<File> coverageFileOf(final String serial) {
+    return new CustomTypeSafeMatcher<File>("") {
+      @Override
+      protected boolean matchesSafely(File file) {
+        assertThat(file.getPath(), is("/output/coverage/" + SpoonUtils.sanitizeSerial(serial) + "/coverage.ec"));
+        return true;
+      }
+    };
+  }
+}

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.java
@@ -1,5 +1,6 @@
 package com.squareup.spoon;
 
+import com.google.common.collect.ImmutableSet;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.jacoco.core.tools.ExecFileLoader;
 import org.junit.Test;
@@ -7,6 +8,7 @@ import org.mockito.ArgumentCaptor;
 
 import java.io.File;
 import java.util.HashSet;
+import java.util.Set;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,7 +24,7 @@ public class SpoonCoverageMergerTest {
   @Test
   public void shouldMergeCoverageFiles() throws Exception {
     ExecFileLoader execFileLoader = mock(ExecFileLoader.class);
-    HashSet<String> serials = new HashSet<String>(asList("10.0.0.1:1234", "10.0.0.2:1234"));
+    Set<String> serials = ImmutableSet.of("10.0.0.1:1234", "10.0.0.2:1234");
     File spoonOutputDirectory = new File("/output");
 
     SpoonCoverageMerger spoonCoverageMerger = new SpoonCoverageMerger(execFileLoader);


### PR DESCRIPTION
With this change, spoon plugin has the capability to merge multiple coverage files generated from multiple devices into one file called `merged-coverage.ec`. 
This functionality is useful when a user has provided the option like `--shard` to divide the whole test suite to run on multiple devices and getting different coverage files. Now spoon plugin is able to merge all these coverage files  and save the merged file as  `{spoon output directory}/coverage/merged-coverage.ec`.