### PR TITLE
Parse a job as failure if there were top level excpetions, even if some tests were run

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -269,8 +269,8 @@ public final class SpoonRunner {
       if (result.getInstallFailed()) {
         return false; // App and/or test installation failed.
       }
-      if (!result.getExceptions().isEmpty() && result.getTestResults().isEmpty()) {
-        return false; // No tests run and top-level exception present.
+      if (!result.getExceptions().isEmpty || result.getTestResults().isEmpty()) {
+        return false; // Top-level exception present, or no tests were run
       }
       for (DeviceTestResult methodResult : result.getTestResults().values()) {
         if (methodResult.getStatus() != Status.PASS) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -269,8 +269,8 @@ public final class SpoonRunner {
       if (result.getInstallFailed()) {
         return false; // App and/or test installation failed.
       }
-      if (!result.getExceptions().isEmpty()) {
-        return false; // Top-level exception present.
+      if (!result.getExceptions().isEmpty() || result.getTestResults().isEmpty()) {
+        return false; // Top-level exception present, or no tests were run.
       }
       for (DeviceTestResult methodResult : result.getTestResults().values()) {
         if (methodResult.getStatus() != Status.PASS) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -270,7 +270,7 @@ public final class SpoonRunner {
         return false; // App and/or test installation failed.
       }
       if (!result.getExceptions().isEmpty() || result.getTestResults().isEmpty()) {
-        return false; // Top-level exception present, or no tests were run
+        return false; // Top-level exception present, or no tests were run.
       }
       for (DeviceTestResult methodResult : result.getTestResults().values()) {
         if (methodResult.getStatus() != Status.PASS) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -269,7 +269,7 @@ public final class SpoonRunner {
       if (result.getInstallFailed()) {
         return false; // App and/or test installation failed.
       }
-      if (!result.getExceptions().isEmpty || result.getTestResults().isEmpty()) {
+      if (!result.getExceptions().isEmpty() || result.getTestResults().isEmpty()) {
         return false; // Top-level exception present, or no tests were run
       }
       for (DeviceTestResult methodResult : result.getTestResults().values()) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -269,8 +269,8 @@ public final class SpoonRunner {
       if (result.getInstallFailed()) {
         return false; // App and/or test installation failed.
       }
-      if (!result.getExceptions().isEmpty() || result.getTestResults().isEmpty()) {
-        return false; // Top-level exception present, or no tests were run.
+      if (!result.getExceptions().isEmpty()) {
+        return false; // Top-level exception present.
       }
       for (DeviceTestResult methodResult : result.getTestResults().values()) {
         if (methodResult.getStatus() != Status.PASS) {

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
@@ -45,13 +45,16 @@ public class SpoonRunnerTest {
             .addResult("123", new DeviceResult.Builder() //
                     .addException(new RuntimeException())
                     .startTests() //
+                    .addTestResultBuilder(device, new DeviceTestResult.Builder() //
+                            .startTest() //
+                            .endTest()) //
                     .endTests() //
                     .build()) //
             .end() //
             .build(); //
     assertThat(parseOverallSuccess(summary)).isFalse();
 
-    // PASS: No tests run.
+    // FAIL: No tests run.
     summary = new SpoonSummary.Builder() //
         .setTitle("test") //
         .start() //
@@ -61,7 +64,7 @@ public class SpoonRunnerTest {
             .build()) //
         .end() //
         .build(); //
-    assertThat(parseOverallSuccess(summary)).isTrue();
+    assertThat(parseOverallSuccess(summary)).isFalse();
 
     // FAIL: Test failure.
     summary = new SpoonSummary.Builder() //

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
@@ -38,7 +38,7 @@ public class SpoonRunnerTest {
         .build(); //
     assertThat(parseOverallSuccess(summary)).isFalse();
 
-    // FAIL: Top-level exception during test run
+    // FAIL: Top-level exception during test run.
     summary = new SpoonSummary.Builder() //
             .setTitle("test") //
             .start() //

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
@@ -38,6 +38,19 @@ public class SpoonRunnerTest {
         .build(); //
     assertThat(parseOverallSuccess(summary)).isFalse();
 
+    // FAIL: Top-level exception during test run
+    summary = new SpoonSummary.Builder() //
+            .setTitle("test") //
+            .start() //
+            .addResult("123", new DeviceResult.Builder() //
+                    .addException(new RuntimeException())
+                    .startTests() //
+                    .endTests() //
+                    .build()) //
+            .end() //
+            .build(); //
+    assertThat(parseOverallSuccess(summary)).isFalse();
+
     // PASS: No tests run.
     summary = new SpoonSummary.Builder() //
         .setTitle("test") //


### PR DESCRIPTION
We saw this recently in one of our runs:

![screenshot from 2016-06-15 15 45 47](https://cloud.githubusercontent.com/assets/4722184/16100078/c21c5e2e-3310-11e6-8618-a71f70e9b1f8.png)

We have a top level exception present, but it occurred in the middle of running tests. So, as long as some tests have executed, the logic in parseOverallSuccess marks the run as a success. However, we haven't executed all the tests, so this should really be marked as a failure.  I think the logic here should be || instead of &&...can anyone justify why it's currently &&?

