### PR TITLE
Bumped ddmlib version from 24.5.0 to 25.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
       <dependency>
         <groupId>com.android.tools.ddms</groupId>
         <artifactId>ddmlib</artifactId>
-        <version>24.5.0</version>
+        <version>25.1.2</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Solves #302 [issue](https://code.google.com/p/android/issues/detail?id=195998).
`Exception in thread "Thread-1" java.lang.IllegalStateException: No logcat header processed yet, failed to parse line: --------- beginning of system`