### PR TITLE
Exception when the model of device is blank

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceUtils.java
@@ -9,7 +9,7 @@ final class DeviceUtils {
     if (model.regionMatches(true, 0, manufacturer, 0, manufacturer.length())) {
       model = model.substring(manufacturer.length());
     }
-    if (model.charAt(0) == ' ' || model.charAt(0) == '-') {
+    if (model.length() > 0 && (model.charAt(0) == ' ' || model.charAt(0) == '-')) {
       model = model.substring(1);
     }
     return model;


### PR DESCRIPTION
If you try run the tests in one device and the name of the model is blank, It doesn't work and it shows the following error:

Exception in thread "main" java.lang.StringIndexOutOfBoundsException: String ind
ex out of range: 0
        at java.lang.String.charAt(Unknown Source)
        at com.squareup.spoon.DeviceUtils.scrubModel(DeviceUtils.java:12)
        at com.squareup.spoon.DeviceDetails.createForDevice(DeviceDetails.java:8
6)
        at com.squareup.spoon.SpoonUtils.findAllDevices(SpoonUtils.java:108)
        at com.squareup.spoon.SpoonRunner.run(SpoonRunner.java:119)
        at com.squareup.spoon.SpoonRunner.main(SpoonRunner.java:663)