### PR TITLE
Spoon runner: no test results on one device doesn't necessarily indic…

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -275,12 +275,21 @@ public final class SpoonRunner {
 
   /** Returns {@code false} if a test failed on any device. */
   static boolean parseOverallSuccess(SpoonSummary summary) {
+    if (summary.getResults().size() == 0) {
+      return true;
+    }
+
+
+    boolean sawTestResults = false;
     for (DeviceResult result : summary.getResults().values()) {
       if (result.getInstallFailed()) {
         return false; // App and/or test installation failed.
       }
-      if (!result.getExceptions().isEmpty() || result.getTestResults().isEmpty()) {
+      if (!result.getExceptions().isEmpty()) {
         return false; // Top-level exception present, or no tests were run.
+      }
+      if (!result.getTestResults().isEmpty()) {
+        sawTestResults = true;
       }
       for (DeviceTestResult methodResult : result.getTestResults().values()) {
         if (methodResult.getStatus() != Status.PASS) {
@@ -288,7 +297,7 @@ public final class SpoonRunner {
         }
       }
     }
-    return true;
+    return sawTestResults;
   }
 
   private SpoonDeviceRunner getTestRunner(String serial, int shardIndex, int numShards,


### PR DESCRIPTION
…ate failure

Saw this issue when sharding across multiple devices with a small number of tests that happened to hash collide onto the same device. In this case there was no actual issue but spoon runner was reporting failure anyway.
