### PR TITLE
add posibility to exclude devices from testing

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -10,8 +10,6 @@ import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.converters.IParameterSplitter;
 import com.google.common.collect.ImmutableSet;
 import com.squareup.spoon.html.HtmlRenderer;
-import org.apache.commons.io.FileUtils;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +23,7 @@ import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.apache.commons.io.FileUtils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -37,8 +36,8 @@ import static java.util.Collections.synchronizedSet;
 
 /** Represents a collection of devices and the test configuration to be executed. */
 public final class SpoonRunner {
-  private static final String DEFAULT_TITLE = "Spoon Execution";
   public static final String DEFAULT_OUTPUT_DIRECTORY = "spoon-output";
+  private static final String DEFAULT_TITLE = "Spoon Execution";
   private static final int DEFAULT_ADB_TIMEOUT_SEC = 10 * 60; //10 minutes
   private final ExecutorService threadExecutor;
 
@@ -54,18 +53,20 @@ public final class SpoonRunner {
   private final String className;
   private final String methodName;
   private final Set<String> serials;
+  private final Set<String> skipDevices;
   private final boolean shard;
   private final String classpath;
   private final IRemoteAndroidTestRunner.TestSize testSize;
-  private boolean codeCoverage;
   private final boolean failIfNoDeviceConnected;
   private final List<ITestRunListener> testRunListeners;
   private final boolean terminateAdb;
-  private File initScript;
   private final boolean grantAll;
+  private boolean codeCoverage;
+  private File initScript;
 
   private SpoonRunner(String title, File androidSdk, File applicationApk, File instrumentationApk,
       File output, boolean debug, boolean noAnimations, int adbTimeoutMillis, Set<String> serials,
+      Set<String> skipDevices,
       boolean shard, String classpath, List<String> instrumentationArgs, String className,
       String methodName, IRemoteAndroidTestRunner.TestSize testSize,
       boolean failIfNoDeviceConnected, List<ITestRunListener> testRunListeners, boolean sequential,
@@ -83,6 +84,7 @@ public final class SpoonRunner {
     this.methodName = methodName;
     this.classpath = classpath;
     this.testSize = testSize;
+    this.skipDevices = skipDevices;
     this.codeCoverage = codeCoverage;
     this.serials = ImmutableSet.copyOf(serials);
     this.shard = shard;
@@ -96,6 +98,91 @@ public final class SpoonRunner {
       this.threadExecutor = Executors.newSingleThreadExecutor();
     } else {
       this.threadExecutor = Executors.newCachedThreadPool();
+    }
+  }
+
+  /** Returns {@code false} if a test failed on any device. */
+  static boolean parseOverallSuccess(SpoonSummary summary) {
+    for (DeviceResult result : summary.getResults().values()) {
+      if (result.getInstallFailed()) {
+        return false; // App and/or test installation failed.
+      }
+      if (!result.getExceptions().isEmpty() || result.getTestResults().isEmpty()) {
+        return false; // Top-level exception present, or no tests were run.
+      }
+      for (DeviceTestResult methodResult : result.getTestResults().values()) {
+        if (methodResult.getStatus() != Status.PASS) {
+          return false; // Individual test failure.
+        }
+      }
+    }
+    return true;
+  }
+
+  private static File cleanFile(String path) {
+    if (path == null) {
+      return null;
+    }
+    return new File(path);
+  }
+
+  public static void main(String... args) {
+    CommandLineArgs parsedArgs = new CommandLineArgs();
+    JCommander jc = new JCommander(parsedArgs);
+
+    try {
+      jc.parse(args);
+    } catch (ParameterException e) {
+      StringBuilder out = new StringBuilder(e.getLocalizedMessage()).append("\n\n");
+      jc.usage(out);
+      System.err.println(out.toString());
+      System.exit(1);
+      return;
+    }
+    if (parsedArgs.help) {
+      jc.usage();
+      return;
+    }
+
+    Builder builder = new SpoonRunner.Builder() //
+        .setTitle(parsedArgs.title)
+        .setApplicationApk(parsedArgs.apk)
+        .setInstrumentationApk(parsedArgs.testApk)
+        .setOutputDirectory(parsedArgs.output)
+        .setDebug(parsedArgs.debug)
+        .setAndroidSdk(parsedArgs.sdk)
+        .setNoAnimations(parsedArgs.noAnimations)
+        .setTestSize(parsedArgs.size)
+        .setAdbTimeout(parsedArgs.adbTimeoutSeconds * 1000)
+        .setFailIfNoDeviceConnected(parsedArgs.failIfNoDeviceConnected)
+        .setSequential(parsedArgs.sequential)
+        .setInitScript(parsedArgs.initScript)
+        .setGrantAll(parsedArgs.grantAll)
+        .setInstrumentationArgs(parsedArgs.instrumentationArgs)
+        .setCodeCoverage(parsedArgs.codeCoverage)
+        .setClassName(parsedArgs.className)
+        .setMethodName(parsedArgs.methodName)
+        .setShard(parsedArgs.shard);
+
+    if (parsedArgs.serials == null || parsedArgs.serials.isEmpty()) {
+      builder.useAllAttachedDevices();
+    } else {
+      for (String serial : parsedArgs.serials) {
+        builder.addDevice(serial);
+      }
+    }
+
+    //checks if there are any devices to skip testing on
+    if (parsedArgs.skipDevices != null && !parsedArgs.skipDevices.isEmpty()) {
+      for (String serial : parsedArgs.skipDevices) {
+        builder.skipDevice(serial);
+      }
+    }
+
+    SpoonRunner spoonRunner = builder.build();
+
+    if (!spoonRunner.run() && parsedArgs.failOnFailure) {
+      System.exit(1);
     }
   }
 
@@ -118,6 +205,10 @@ public final class SpoonRunner {
       if (serials.isEmpty()) {
         serials = SpoonUtils.findAllDevices(adb, testInfo.getMinSdkVersion());
       }
+      //skipping selected devices if any
+      if (this.skipDevices != null && !this.skipDevices.isEmpty()) {
+        serials.removeAll(this.skipDevices);
+      }
       if (failIfNoDeviceConnected && serials.isEmpty()) {
         throw new RuntimeException("No device(s) found.");
       }
@@ -137,7 +228,7 @@ public final class SpoonRunner {
 
   private SpoonSummary runTests(AndroidDebugBridge adb, Set<String> serials) {
     int targetCount = serials.size();
-    logInfo("Executing instrumentation suite on %d device(s).", targetCount);
+    logInfo("Executing instrumdentation suite on %d device(s).", targetCount);
 
     try {
       FileUtils.deleteDirectory(output);
@@ -273,24 +364,6 @@ public final class SpoonRunner {
     }
   }
 
-  /** Returns {@code false} if a test failed on any device. */
-  static boolean parseOverallSuccess(SpoonSummary summary) {
-    for (DeviceResult result : summary.getResults().values()) {
-      if (result.getInstallFailed()) {
-        return false; // App and/or test installation failed.
-      }
-      if (!result.getExceptions().isEmpty() || result.getTestResults().isEmpty()) {
-        return false; // Top-level exception present, or no tests were run.
-      }
-      for (DeviceTestResult methodResult : result.getTestResults().values()) {
-        if (methodResult.getStatus() != Status.PASS) {
-          return false; // Individual test failure.
-        }
-      }
-    }
-    return true;
-  }
-
   private SpoonDeviceRunner getTestRunner(String serial, int shardIndex, int numShards,
       SpoonInstrumentationInfo testInfo) {
     return new SpoonDeviceRunner(androidSdk, applicationApk, instrumentationApk, output, serial,
@@ -308,6 +381,7 @@ public final class SpoonRunner {
     private File output;
     private boolean debug = false;
     private Set<String> serials;
+    private Set<String> skipDevices;
     private String classpath = System.getProperty("java.class.path");
     private List<String> instrumentationArgs;
     private String className;
@@ -391,10 +465,23 @@ public final class SpoonRunner {
       return this;
     }
 
+    /** Add a device serial for skipping test execution. */
+    public Builder skipDevice(String serial) {
+      checkNotNull(serial, "Serial cannot be null.");
+      if (skipDevices == null) {
+        skipDevices = new LinkedHashSet<String>();
+      }
+      skipDevices.add(serial);
+      return this;
+    }
+
     /** Use all currently attached device serials when executed. */
     public Builder useAllAttachedDevices() {
       if (this.serials != null) {
         throw new IllegalStateException("Serial list already contains entries.");
+      }
+      if (this.skipDevices != null) {
+        logInfo("Skipping devices not empty, will skip following serials: ", skipDevices);
       }
       if (this.androidSdk == null) {
         throw new IllegalStateException("SDK must be set before calling this method.");
@@ -488,16 +575,16 @@ public final class SpoonRunner {
       }
 
       return new SpoonRunner(title, androidSdk, applicationApk, instrumentationApk, output, debug,
-          noAnimations, adbTimeoutMillis, serials, shard, classpath, instrumentationArgs, className,
+          noAnimations, adbTimeoutMillis, serials, skipDevices, shard, classpath,
+          instrumentationArgs, className,
           methodName, testSize, failIfNoDeviceConnected, testRunListeners, sequential, initScript,
           grantAll, terminateAdb, codeCoverage);
     }
   }
 
   /**
-   * Instances where string input should not be split there needs to
-   * be a way override the default splitting behavior.
-   * This class provides that options
+   * Instances where string input should not be split there needs to be a way override the default
+   * splitting behavior. This class provides that options
    */
   public static class NoSplitter implements IParameterSplitter {
     @Override public List<String> split(String value) {
@@ -558,7 +645,7 @@ public final class SpoonRunner {
 
     @Parameter(names = { "--grant-all" },
         description = "Grant all runtime permissions during installation on Marshmallow and above"
-                + " devices") //
+            + " devices") //
     public boolean grantAll;
 
     @Parameter(names = { "--no-animations" }, description = "Disable animated gif generation")
@@ -567,31 +654,22 @@ public final class SpoonRunner {
     @Parameter(names = { "--adb-timeout" },
         description = "Set maximum execution time per test in seconds (10min default)") //
     public int adbTimeoutSeconds = DEFAULT_ADB_TIMEOUT_SEC;
-
+    @Parameter(names = { "--shard" },
+        description = "Automatically shard across all specified serials") //
+    public boolean shard;
+    @Parameter(names = { "--debug" }, hidden = true) //
+    public boolean debug;
+    @Parameter(names = { "--coverage" }, description = "Code coverage flag", arity = 1)
+    public Boolean codeCoverage = false;
+    @Parameter(names = { "-h", "--help" }, description = "Command help", help = true, hidden = true)
+    public boolean help;
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") //
     @Parameter(names = "-serial",
         description = "Serial of the device to use (May be used multiple times)")
     private List<String> serials = new ArrayList<String>();
-
-    @Parameter(names = { "--shard" },
-        description = "Automatically shard across all specified serials") //
-    public boolean shard;
-
-    @Parameter(names = { "--debug" }, hidden = true) //
-    public boolean debug;
-
-    @Parameter(names = { "--coverage" }, description = "Code coverage flag", arity = 1)
-    public Boolean codeCoverage = false;
-
-    @Parameter(names = { "-h", "--help" }, description = "Command help", help = true, hidden = true)
-    public boolean help;
-  }
-
-  private static File cleanFile(String path) {
-    if (path == null) {
-      return null;
-    }
-    return new File(path);
+    @Parameter(names = "-skipDevices",
+        description = "Serial of the device to skip (May be used multiple times)")
+    private List<String> skipDevices = new ArrayList<String>();
   }
 
   /* JCommander deems it necessary that this class be public. Lame. */
@@ -609,59 +687,6 @@ public final class SpoonRunner {
       } catch (IllegalArgumentException e) {
         throw new ParameterException(e.getMessage());
       }
-    }
-  }
-
-  public static void main(String... args) {
-    CommandLineArgs parsedArgs = new CommandLineArgs();
-    JCommander jc = new JCommander(parsedArgs);
-
-    try {
-      jc.parse(args);
-    } catch (ParameterException e) {
-      StringBuilder out = new StringBuilder(e.getLocalizedMessage()).append("\n\n");
-      jc.usage(out);
-      System.err.println(out.toString());
-      System.exit(1);
-      return;
-    }
-    if (parsedArgs.help) {
-      jc.usage();
-      return;
-    }
-
-    Builder builder = new SpoonRunner.Builder() //
-        .setTitle(parsedArgs.title)
-        .setApplicationApk(parsedArgs.apk)
-        .setInstrumentationApk(parsedArgs.testApk)
-        .setOutputDirectory(parsedArgs.output)
-        .setDebug(parsedArgs.debug)
-        .setAndroidSdk(parsedArgs.sdk)
-        .setNoAnimations(parsedArgs.noAnimations)
-        .setTestSize(parsedArgs.size)
-        .setAdbTimeout(parsedArgs.adbTimeoutSeconds * 1000)
-        .setFailIfNoDeviceConnected(parsedArgs.failIfNoDeviceConnected)
-        .setSequential(parsedArgs.sequential)
-        .setInitScript(parsedArgs.initScript)
-        .setGrantAll(parsedArgs.grantAll)
-        .setInstrumentationArgs(parsedArgs.instrumentationArgs)
-        .setCodeCoverage(parsedArgs.codeCoverage)
-        .setClassName(parsedArgs.className)
-        .setMethodName(parsedArgs.methodName)
-        .setShard(parsedArgs.shard);
-
-    if (parsedArgs.serials == null || parsedArgs.serials.isEmpty()) {
-      builder.useAllAttachedDevices();
-    } else {
-      for (String serial : parsedArgs.serials) {
-        builder.addDevice(serial);
-      }
-    }
-
-    SpoonRunner spoonRunner = builder.build();
-
-    if (!spoonRunner.run() && parsedArgs.failOnFailure) {
-      System.exit(1);
     }
   }
 }

--- a/spoon-sample/app/pom.xml
+++ b/spoon-sample/app/pom.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>spoon-sample</artifactId>
-    <version>1.1.9-SNAPSHOT</version>
+    <version>1.6.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>spoon-sample-app</artifactId>

--- a/spoon-sample/pom.xml
+++ b/spoon-sample/pom.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>parent</artifactId>
-    <version>1.1.9-SNAPSHOT</version>
+    <version>1.6.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>spoon-sample</artifactId>

--- a/spoon-sample/tests/pom.xml
+++ b/spoon-sample/tests/pom.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.squareup.spoon</groupId>
     <artifactId>spoon-sample</artifactId>
-    <version>1.1.9-SNAPSHOT</version>
+    <version>1.6.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>spoon-sample-tests</artifactId>

--- a/test-cli.sh
+++ b/test-cli.sh
@@ -8,6 +8,7 @@ set -e
 APK=`\ls spoon-sample/app/target/*.apk`
 TEST_APK=`\ls spoon-sample/tests/target/*.apk`
 
-java -jar spoon-runner/target/spoon-*-jar-with-dependencies.jar --apk "$APK" --test-apk "$TEST_APK" --output target
+#java -jar spoon-runner/target/spoon-*-jar-with-dependencies.jar --apk "$APK" --test-apk "$TEST_APK" -skipDevices "emulator-5556" --output target
+java -jar spoon-runner/target/spoon-*-jar-with-dependencies.jar --apk "$APK" --test-apk "$TEST_APK"  --output target
 
 open target/index.html


### PR DESCRIPTION
this can be useful if there are dedicated tests in automation that should not be touched by other test suites

gives greater control over hardware used for testing

applied the square codestyle to changes:
https://github.com/square/java-code-styles


bumped android app spoon runner version and added example in  test-cli.sh how to exclude a device(s)