### PR TITLE
Better handling of double results

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
@@ -11,13 +11,14 @@ import java.util.concurrent.TimeUnit;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.Collections.unmodifiableList;
+import static com.squareup.spoon.SpoonLogger.logError;
 
 public final class DeviceTestResult {
   /** Separator between screenshot timestamp and tag. */
   public static final String SCREENSHOT_SEPARATOR = Spoon.NAME_SEPARATOR;
 
   public enum Status {
-    PASS, FAIL, ERROR
+    PASS, FAIL
   }
 
   private final Status status;
@@ -85,18 +86,10 @@ public final class DeviceTestResult {
 
     public Builder markTestAsFailed(String message) {
       checkNotNull(message);
-      checkArgument(status == Status.PASS || status == status.FAIL,
-        "Status was already marked as " + status);
+      if (status != Status.PASS) {
+        logError("Status was already marked as failed!");
+      }
       status = Status.FAIL;
-      exception = StackTrace.from(message);
-      return this;
-    }
-
-    public Builder markTestAsError(String message) {
-      checkNotNull(message);
-      checkArgument(status == Status.PASS || status == status.ERROR,
-        "Status was already marked as " + status);
-      status = Status.ERROR;
       exception = StackTrace.from(message);
       return this;
     }
@@ -116,7 +109,9 @@ public final class DeviceTestResult {
 
     public Builder endTest() {
       checkArgument(start != 0, "Start was not called.");
-      checkArgument(duration == -1, "End was already called.");
+      if (duration != -1) {
+        logError("Test was already marked as ended!");
+      }
       duration = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start);
       return this;
     }

--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
@@ -85,7 +85,8 @@ public final class DeviceTestResult {
 
     public Builder markTestAsFailed(String message) {
       checkNotNull(message);
-      checkArgument(status == Status.PASS, "Status was already marked as " + status);
+      checkArgument(status == Status.PASS || status == status.FAIL,
+        "Status was already marked as " + status);
       status = Status.FAIL;
       exception = StackTrace.from(message);
       return this;
@@ -93,7 +94,8 @@ public final class DeviceTestResult {
 
     public Builder markTestAsError(String message) {
       checkNotNull(message);
-      checkArgument(status == Status.PASS, "Status was already marked as " + status);
+      checkArgument(status == Status.PASS || status == status.ERROR,
+        "Status was already marked as " + status);
       status = Status.ERROR;
       exception = StackTrace.from(message);
       return this;

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlLog.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlLog.java
@@ -17,9 +17,6 @@ final class HtmlLog {
       case FAIL:
         status = "failed";
         break;
-      case ERROR:
-        status = "errored";
-        break;
       default:
         throw new IllegalArgumentException("Unknown status: " + result.getStatus());
     }

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
@@ -89,9 +89,6 @@ final class HtmlUtils {
       case FAIL:
         status = "fail";
         break;
-      case ERROR:
-        status = "error";
-        break;
       default:
         throw new IllegalArgumentException("Unknown result status: " + testResult.getStatus());
     }

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
@@ -81,21 +81,6 @@ public class SpoonRunnerTest {
         .build(); //
     assertThat(parseOverallSuccess(summary)).isFalse();
 
-    // FAIL: Test error.
-    summary = new SpoonSummary.Builder() //
-        .setTitle("test") //
-        .start() //
-        .addResult("123", new DeviceResult.Builder() //
-            .startTests() //
-            .addTestResultBuilder(device, new DeviceTestResult.Builder() //
-                .startTest() //
-                .markTestAsError("java.fake.Exception: Failed!")
-                .endTest()) //
-            .build()) //
-        .end() //
-        .build(); //
-    assertThat(parseOverallSuccess(summary)).isFalse();
-
     // PASS: Test success.
     summary = new SpoonSummary.Builder() //
         .setTitle("test") //


### PR DESCRIPTION
In issue #370, we noticed that there are some circumstances where the TestRunListener can get more than one testFailed event.  My fix wasn't good enough, it just pushed the problem down the chain since we'd fail on the second testEnded.  This still produced the undesired behaviour of failing to generate an xml report for the run.

This PR cleans that up, adds error logging when it occurs, and rips out everything related to Status.Error, which we discovered isn't used by JUnit anymore.