### PR TITLE
HTML escape exception titles

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
@@ -12,6 +12,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import static com.squareup.spoon.DeviceTestResult.SCREENSHOT_SEPARATOR;
 
@@ -191,7 +192,9 @@ final class HtmlUtils {
     if (exception == null) {
       return null;
     }
-    String message = exception.toString().replace("\n", "<br/>");
+    // Escape any special HTML characters in the exception that would otherwise break the HTML
+    // rendering (e.g. the angle brackets around the default toString() for enums).
+    String message = StringEscapeUtils.escapeHtml4(exception.toString());
     List<String> lines = new ArrayList<String>();
     for (StackTrace.Element element : exception.getElements()) {
       lines.add("&nbsp;&nbsp;&nbsp;&nbsp;at " + element.toString());

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
@@ -201,7 +201,7 @@ final class HtmlUtils {
     }
     while (exception.getCause() != null) {
       exception = exception.getCause();
-      lines.add("Caused by: " + exception.toString().replace("\n", "<br/>"));
+      lines.add("Caused by: " + StringEscapeUtils.escapeHtml4(exception.toString()));
     }
     return new ExceptionInfo(message, lines);
   }

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonRunnerTest.java
@@ -81,6 +81,21 @@ public class SpoonRunnerTest {
         .build(); //
     assertThat(parseOverallSuccess(summary)).isFalse();
 
+    // FAIL: Test error with special HTML characters in the exception message
+    summary = new SpoonSummary.Builder() //
+            .setTitle("test") //
+            .start() //
+            .addResult("123", new DeviceResult.Builder() //
+                    .startTests() //
+                    .addTestResultBuilder(device, new DeviceTestResult.Builder() //
+                            .startTest() //
+                            .markTestAsFailed("java.fake.Exception: Expected <SUCCESS> but was <FAILED>!")
+                            .endTest()) //
+                    .build()) //
+            .end() //
+            .build(); //
+    assertThat(parseOverallSuccess(summary)).isFalse();
+
     // PASS: Test success.
     summary = new SpoonSummary.Builder() //
         .setTitle("test") //

--- a/spoon-runner/src/test/java/com/squareup/spoon/html/HtmlUtilsTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/html/HtmlUtilsTest.java
@@ -1,11 +1,15 @@
 package com.squareup.spoon.html;
 
 import java.io.File;
+import java.util.List;
 import org.junit.Test;
+import com.squareup.spoon.html.HtmlUtils.ExceptionInfo;
+import com.squareup.spoon.misc.StackTrace;
 
 import static com.squareup.spoon.html.HtmlUtils.createRelativeUri;
 import static com.squareup.spoon.html.HtmlUtils.prettifyImageName;
 import static com.squareup.spoon.html.HtmlUtils.prettifyMethodName;
+import static com.squareup.spoon.html.HtmlUtils.processStackTrace;
 import static com.squareup.spoon.html.HtmlUtils.humanReadableDuration;
 import static org.fest.assertions.api.Assertions.assertThat;
 
@@ -63,5 +67,22 @@ public class HtmlUtilsTest {
     assertThat(humanReadableDuration(62)).isEqualTo("1 minute, 2 seconds");
     assertThat(humanReadableDuration(122)).isEqualTo("2 minutes, 2 seconds");
     assertThat(humanReadableDuration(3661)).isEqualTo("61 minutes, 1 second");
+  }
+
+  @Test public void processStackTraceHtmlEscapeAngleBrackets() {
+    StackTrace exception = StackTrace.from(""
+            + "java.fake.Exception: Expected <SUCCESS> but was <FAILED>!\n"
+            + " at android.fake.FakeClass.fakeMethod(FakeClass.java:1)\n"
+            + " at android.fake.FakeClass.fakeMethod(FakeClass.java:2)\n");
+    ExceptionInfo exceptionInfo = processStackTrace(exception);
+    assertThat(exceptionInfo.title).isEqualTo(""
+            + "java.fake.Exception: Expected &lt;SUCCESS&gt; but was &lt;FAILED&gt;!");
+    List<String> lines = exceptionInfo.body;
+    assertThat(lines).isNotNull();
+    assertThat(lines.size()).isEqualTo(2);
+    assertThat(lines.get(0)).isEqualTo(""
+            + "&nbsp;&nbsp;&nbsp;&nbsp;at android.fake.FakeClass.fakeMethod(FakeClass.java:1)");
+    assertThat(lines.get(1)).isEqualTo(""
+            + "&nbsp;&nbsp;&nbsp;&nbsp;at android.fake.FakeClass.fakeMethod(FakeClass.java:2)");
   }
 }

--- a/spoon-runner/src/test/java/com/squareup/spoon/html/HtmlUtilsTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/html/HtmlUtilsTest.java
@@ -73,16 +73,21 @@ public class HtmlUtilsTest {
     StackTrace exception = StackTrace.from(""
             + "java.fake.Exception: Expected <SUCCESS> but was <FAILED>!\n"
             + " at android.fake.FakeClass.fakeMethod(FakeClass.java:1)\n"
-            + " at android.fake.FakeClass.fakeMethod(FakeClass.java:2)\n");
+            + " at android.fake.FakeClass.fakeMethod(FakeClass.java:2)\n"
+            + "Caused by: java.lang.IllegalArgumentException: Inner exception <FAILED>\n"
+            + " at android.fake.FakeClass.fakeMethod(FakeClass.java:3)\n");
     ExceptionInfo exceptionInfo = processStackTrace(exception);
     assertThat(exceptionInfo.title).isEqualTo(""
             + "java.fake.Exception: Expected &lt;SUCCESS&gt; but was &lt;FAILED&gt;!");
     List<String> lines = exceptionInfo.body;
     assertThat(lines).isNotNull();
-    assertThat(lines.size()).isEqualTo(2);
+    assertThat(lines.size()).isEqualTo(3);
     assertThat(lines.get(0)).isEqualTo(""
             + "&nbsp;&nbsp;&nbsp;&nbsp;at android.fake.FakeClass.fakeMethod(FakeClass.java:1)");
     assertThat(lines.get(1)).isEqualTo(""
             + "&nbsp;&nbsp;&nbsp;&nbsp;at android.fake.FakeClass.fakeMethod(FakeClass.java:2)");
+    assertThat(lines.get(2)).isEqualTo(""
+            + "Caused by: java.lang.IllegalArgumentException: Inner exception &lt;FAILED&gt;");
+    // The stack trace for the "Caused by" exception does not get printed
   }
 }


### PR DESCRIPTION
This PR is based on the proposal I made in this issue: https://github.com/square/spoon/issues/154#issuecomment-238441391

## NOTES

I originally wanted to leave the "\n" to "&lt;br/&gt;" replacement code in place.  However, I wrote this test to attempt to check it worked as expected:

```
 @Test public void processStackTraceConvertsNewlinesToHtml() {
    StackTrace exception = StackTrace.from(""
            + "java.fake.Exception: Failed!\n"
            + " at android.fake.FakeClass.fakeMethod(FakeClass.java:1)\n"
            + " at android.fake.FakeClass.fakeMethod(FakeClass.java:2)\n");
    ExceptionInfo exceptionInfo = processStackTrace(exception);
    assertThat(exceptionInfo.title).isEqualTo("java.fake.Exception: Failed!<br/>");
    List<String> lines = exceptionInfo.body;
    assertThat(lines).isNotNull();
    assertThat(lines.size()).isEqualTo(1);
    assertThat(lines.get(0)).isEqualTo(""
            + "&nbsp;&nbsp;&nbsp;&nbsp;at android.fake.FakeClass.fakeMethod(FakeClass.java:1)<br/>");
    assertThat(lines.get(1)).isEqualTo(""
            + "&nbsp;&nbsp;&nbsp;&nbsp;at android.fake.FakeClass.fakeMethod(FakeClass.java:2)<br/>");
  }
```
This test failed (even when I removed all my changes) with this assertion failure (the &lt;br/&gt; elements are not being added):
```
processStackTraceConvertsNewlinesToHtml(com.squareup.spoon.html.HtmlUtilsTest)  Time elapsed: 0.075 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<...e.Exception: Failed![<br/>]'> but was:<...e.Exception: Failed![]'>
```
Basically, that newline escaping doesn't appear to do anything.  When I checked the HTML for my existing Spoon output (version 1.2.0) I found there were no &lt;br/&gt; tags in the HTML.  Here's sample HTML:
```
<h4 data-toggle="collapse" data-target="#stacktrace-0">java.lang.IllegalStateException: Couldn't match exception header.</h4>

<div class="alert-error stacktrace-body collapse" id="stacktrace-0">

<div class="stacktrace-line">&nbsp;&nbsp;&nbsp;&nbsp;at com.squareup.spoon.misc.StackTrace.acceptTrace(StackTrace.java:85)</div>
```
I'm not sure exactly how the newlines are getting removed, but based on my testing it seems that the &lt;br/&gt; replacements aren't actually doing anything.

## TESTING

 - Unit tests all pass (mvn test).
 - Built the 1.6.5-SNAPSHOT locally (mvn package) and checked that it resolved my HTML escaping problem.

### Before fix (with Spoon 1.2.0):
```
<h4 data-toggle="collapse" data-target="#stacktrace-0">junit.framework.AssertionFailedError: expected:<SUCCESS> but was:<AUTHENTICATE></h4>
```
<img width="543" alt="before" src="https://cloud.githubusercontent.com/assets/739125/17539978/bc6cced2-5e80-11e6-8b5b-33cbab14e2bc.png">

### After fix (with Spoon 1.6.5-SNAPSHOT):
```
<h4 data-toggle="collapse" data-target="#stacktrace-1">junit.framework.AssertionFailedError: expected:&lt;SUCCESS&gt; but was:&lt;AUTHENTICATE&gt;</h4>
```
<img width="724" alt="after" src="https://cloud.githubusercontent.com/assets/739125/17539982/c22b11ee-5e80-11e6-8af4-3deef37d9823.png">
