### PR TITLE
Don't throw an exception when parsing custom format stack traces

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/misc/StackTrace.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/misc/StackTrace.java
@@ -82,7 +82,9 @@ public class StackTrace {
     String header = messageParts.removeFirst();
     Matcher headerMatch = HEADER.matcher(header);
     if (!headerMatch.matches()) {
-      throw new IllegalStateException("Couldn't match exception header.");
+      // The exception doesn't match our expected format, so fallback to something sensible so the
+      // user can still see their test results
+      return new StackTrace("", header, elements, last);
     }
     String exceptionClass = headerMatch.group(1);
 

--- a/spoon-runner/src/test/java/com/squareup/spoon/misc/StackTraceTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/misc/StackTraceTest.java
@@ -133,6 +133,42 @@ public class StackTraceTest {
     assertThat(inner.getElements()).hasSize(2);
   }
 
+  /**
+   * The intent of this test is to check that unexpected format stack traces don't cause any
+   * parsing exceptions.
+   */
+  @Test public void unexpectedFormatException() {
+    String exception = "" +
+            "junit.framework.AssertionFailedError:\n";
+
+    // This exception does not match the expected stack trace format
+    String message = ""
+        + "        **** 2 Assertion Errors Found ****\n"
+        + "\n"
+        + "        --------- Failed Assertion # 1 --------\n"
+        + "junit.framework.AssertionFailedError: 1st expected failure\n"
+        + "at junit.framework.Assert.fail(Assert.java:50)\n"
+        + "at junit.framework.Assert.assertTrue(Assert.java:20)\n"
+        + "at com.capitalone.mobile.wallet.testing.AssertionErrorCollector.assertTrue(AssertionErrorCollector.java:34)\n"
+        + "\n"
+        + "        --------- Failed Assertion # 2 --------\n"
+        + "junit.framework.AssertionFailedError: 2nd expected failure\n"
+        + "at junit.framework.Assert.fail(Assert.java:50)\n"
+        + "at junit.framework.Assert.assertTrue(Assert.java:20)\n"
+        + "at com.capitalone.mobile.wallet.testing.AssertionErrorCollector.assertTrue(AssertionErrorCollector.java:34)\n";
+
+    StackTrace actual = StackTrace.from(exception + message);
+    assertThat(actual.getClassName()).isEqualTo("junit.framework.AssertionFailedError");
+
+    // Due to the unexpected exception format, only the first part of the stack trace gets parsed
+    // into the exception message
+    assertThat(actual.getMessage()).isEqualTo(""
+            + "        **** 2 Assertion Errors Found ****\n"
+            + "\n"
+            + "        --------- Failed Assertion # 1 --------\n"
+            + "junit.framework.AssertionFailedError: 1st expected failure");
+  }
+
   @Test public void nestedExceptionWithMore() {
     String exception = ""
         + "java.lang.NullPointerException: Hello to the world.\n"


### PR DESCRIPTION
Unexpected stack traces used to result in a `java.lang.IllegalStateException: Couldn't match exception header`, causing the test results report to end at the point it hit that exception:
https://github.com/square/spoon/issues/312

The fix is simply to not throw an exception, and to try and display something useful to users. as described here: https://github.com/square/spoon/issues/312#issuecomment-239348204

TESTING
 - The new unit test in StackTraceTest reproduced the original problem, and the passed after applying the fix.
 - Unit tests all pass
 - Retested my original scenario which was hitting this problem.  Instead of throwing the  `java.lang.IllegalStateException`, Spoon now shows a (truncated) stack trace in the results (just like the new unit test).

TODO
 - Rerun the tests after merging https://github.com/square/spoon/pull/374 (I might need to adjust one of my tests to remove the &lt;br/&gt;): 
