### PR TITLE
Don't throw an exception when parsing custom format stack traces

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
@@ -30,7 +30,6 @@ final class HtmlUtils {
     }
   };
 
-
   static String deviceDetailsToString(DeviceDetails details) {
     if (details == null) return null;
 
@@ -195,13 +194,20 @@ final class HtmlUtils {
     // Escape any special HTML characters in the exception that would otherwise break the HTML
     // rendering (e.g. the angle brackets around the default toString() for enums).
     String message = StringEscapeUtils.escapeHtml4(exception.toString());
+
+    // Newline characters are usually stripped out by the parsing code in
+    // {@link StackTrace#from(String)}, but they can sometimes remain (e.g. when the stack trace
+    // is not in an expected format).  This replacement needs to be done after any HTML escaping.
+    message = message.replace("\n", "<br/>");
+
     List<String> lines = new ArrayList<String>();
     for (StackTrace.Element element : exception.getElements()) {
       lines.add("&nbsp;&nbsp;&nbsp;&nbsp;at " + element.toString());
     }
     while (exception.getCause() != null) {
       exception = exception.getCause();
-      lines.add("Caused by: " + StringEscapeUtils.escapeHtml4(exception.toString()));
+      String causeMessage = StringEscapeUtils.escapeHtml4(exception.toString());
+      lines.add("Caused by: " + causeMessage.replace("\n", "<br/>"));
     }
     return new ExceptionInfo(message, lines);
   }

--- a/spoon-runner/src/main/java/com/squareup/spoon/misc/StackTrace.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/misc/StackTrace.java
@@ -82,7 +82,9 @@ public class StackTrace {
     String header = messageParts.removeFirst();
     Matcher headerMatch = HEADER.matcher(header);
     if (!headerMatch.matches()) {
-      throw new IllegalStateException("Couldn't match exception header.");
+      // The exception doesn't match our expected format, so fallback to something sensible so the
+      // user can still see their test results
+      return new StackTrace("", header, elements, last);
     }
     String exceptionClass = headerMatch.group(1);
 

--- a/spoon-runner/src/test/java/com/squareup/spoon/html/HtmlUtilsTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/html/HtmlUtilsTest.java
@@ -69,6 +69,50 @@ public class HtmlUtilsTest {
     assertThat(humanReadableDuration(3661)).isEqualTo("61 minutes, 1 second");
   }
 
+  /**
+   * This test is similar to {@link StackTraceTest#nestedCustomExceptionUnexpectedFormat}.
+   *
+   * The intent of this test is to check that unexpected format exceptions still print something
+   * useful to the user in the test results.
+   */
+  @Test public void processStackTraceUnexpectedFormat() {
+    // This exception does not match the expected stack trace format
+    StackTrace exception = StackTrace.from(""
+            + "        **** 2 Assertion Errors Found ****\n"
+            + "\n"
+            + "        --------- Failed Assertion # 1 --------\n"
+            + "junit.framework.AssertionFailedError: 1st expected failure\n"
+            + "at junit.framework.Assert.fail(Assert.java:50)\n"
+            + "at junit.framework.Assert.assertTrue(Assert.java:20)\n"
+            + "at com.capitalone.mobile.wallet.testing.AssertionErrorCollector.assertTrue(AssertionErrorCollector.java:34)\n"
+            + "\n"
+            + "        --------- Failed Assertion # 2 --------\n"
+            + "junit.framework.AssertionFailedError: 2nd expected failure\n"
+            + "at junit.framework.Assert.fail(Assert.java:50)\n"
+            + "at junit.framework.Assert.assertTrue(Assert.java:20)\n"
+            + "at com.capitalone.mobile.wallet.testing.AssertionErrorCollector.assertTrue(AssertionErrorCollector.java:34)\n");
+    ExceptionInfo exceptionInfo = processStackTrace(exception);
+    // This is one of the rare cases where newline characters need to be converted to <br/>.
+    // Usually newline characters are stripped out by the parsing code in
+    // {@link StackTrace#from(String)}, but it doesn't happen for unexpected format exceptions.
+    assertThat(exceptionInfo.title).isEqualTo(""
+            + "        **** 2 Assertion Errors Found ****: <br/>"
+            + "        --------- Failed Assertion # 1 --------<br/>"
+            + "junit.framework.AssertionFailedError: 1st expected failure");
+    List<String> lines = exceptionInfo.body;
+    assertThat(lines).isNotNull();
+    assertThat(lines.size()).isEqualTo(4);
+    assertThat(lines.get(0)).isEqualTo(""
+            + "&nbsp;&nbsp;&nbsp;&nbsp;at junit.framework.Assert.fail(Assert.java:50)");
+    assertThat(lines.get(1)).isEqualTo(""
+            + "&nbsp;&nbsp;&nbsp;&nbsp;at junit.framework.Assert.assertTrue(Assert.java:20)");
+    assertThat(lines.get(2)).isEqualTo(""
+            + "&nbsp;&nbsp;&nbsp;&nbsp;at com.capitalone.mobile.wallet.testing.AssertionErrorCollector.assertTrue(AssertionErrorCollector.java:34)");
+    // The final line here is "Caused by: ".  This is because the remaining parts of the stack trace
+    // are interpreted as a "Caused by: " exception.  This behavior isn't all that desirable, so we
+    // don't assert it here. :-)
+  }
+
   @Test public void processStackTraceHtmlEscapeAngleBrackets() {
     StackTrace exception = StackTrace.from(""
             + "java.fake.Exception: Expected <SUCCESS> but was <FAILED>!\n"

--- a/spoon-runner/src/test/java/com/squareup/spoon/misc/StackTraceTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/misc/StackTraceTest.java
@@ -133,6 +133,42 @@ public class StackTraceTest {
     assertThat(inner.getElements()).hasSize(2);
   }
 
+  /**
+   * The intent of this test is to check that unexpected format stack traces don't cause any
+   * parsing exceptions.
+   */
+  @Test public void unexpectedFormatException() {
+    String exception = "" +
+            "junit.framework.AssertionFailedError:\n";
+
+    // This exception does not match the expected stack trace format
+    String message = ""
+            + "        **** 2 Assertion Errors Found ****\n"
+            + "\n"
+            + "        --------- Failed Assertion # 1 --------\n"
+            + "junit.framework.AssertionFailedError: 1st expected failure\n"
+            + "at junit.framework.Assert.fail(Assert.java:50)\n"
+            + "at junit.framework.Assert.assertTrue(Assert.java:20)\n"
+            + "at com.capitalone.mobile.wallet.testing.AssertionErrorCollector.assertTrue(AssertionErrorCollector.java:34)\n"
+            + "\n"
+            + "        --------- Failed Assertion # 2 --------\n"
+            + "junit.framework.AssertionFailedError: 2nd expected failure\n"
+            + "at junit.framework.Assert.fail(Assert.java:50)\n"
+            + "at junit.framework.Assert.assertTrue(Assert.java:20)\n"
+            + "at com.capitalone.mobile.wallet.testing.AssertionErrorCollector.assertTrue(AssertionErrorCollector.java:34)\n";
+
+    StackTrace actual = StackTrace.from(exception + message);
+    assertThat(actual.getClassName()).isEqualTo("junit.framework.AssertionFailedError");
+
+    // Due to the unexpected exception format, only the first part of the stack trace gets parsed
+    // into the exception message
+    assertThat(actual.getMessage()).isEqualTo(""
+            + "        **** 2 Assertion Errors Found ****\n"
+            + "\n"
+            + "        --------- Failed Assertion # 1 --------\n"
+            + "junit.framework.AssertionFailedError: 1st expected failure");
+  }
+
   @Test public void nestedExceptionWithMore() {
     String exception = ""
         + "java.lang.NullPointerException: Hello to the world.\n"


### PR DESCRIPTION
Unexpected stack traces used to result in a `java.lang.IllegalStateException: Couldn't match exception header`, causing the test results report to end at the point it hit that exception: https://github.com/square/spoon/issues/312

The fix is to not throw an exception, and to try and display something useful to users. as described here: https://github.com/square/spoon/issues/312#issuecomment-239348204

As part of this change I have reintroduced the newline replacement that I removed in https://github.com/square/spoon/pull/374, since it is needed when you encounter an unexpected format stack trace.

TESTING
 - The new unit test in StackTraceTest reproduced the original problem, and the passed after applying the fix.
 - Unit tests all pass.
 - Retested my original scenario which was hitting this problem.  Instead of throwing the  `java.lang.IllegalStateException`, Spoon now shows a (truncated) stack trace in the results (just like the new unit test):

<img width="603" alt="screen shot 2016-08-20 at 9 45 44 pm" src="https://cloud.githubusercontent.com/assets/739125/17835102/cdfc3cc6-6729-11e6-8c58-befd1924b73f.png">
