### PR TITLE
Add log statement to warn that a view has no height or width

### DIFF
--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -92,6 +92,11 @@ public final class Spoon {
 
   private static void takeScreenshot(File file, final Activity activity) throws IOException {
     View view = activity.getWindow().getDecorView();
+    if (view.getWidth() == 0 || view.getHeight() == 0) {
+      Log.e(TAG, "Your view has no height or width. Are you sure "
+                  + activity.getClass().getSimpleName()
+                  + " is the currently displayed activity?");
+    }
     final Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), ARGB_8888);
 
     if (Looper.myLooper() == Looper.getMainLooper()) {

--- a/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/Spoon.java
@@ -93,9 +93,9 @@ public final class Spoon {
   private static void takeScreenshot(File file, final Activity activity) throws IOException {
     View view = activity.getWindow().getDecorView();
     if (view.getWidth() == 0 || view.getHeight() == 0) {
-      Log.e(TAG, "Your view has no height or width. Are you sure "
-                  + activity.getClass().getSimpleName()
-                  + " is the currently displayed activity?");
+      throw new IOException("Your view has no height or width. Are you sure "
+              + activity.getClass().getSimpleName()
+              + " is the currently displayed activity?");
     }
     final Bitmap bitmap = Bitmap.createBitmap(view.getWidth(), view.getHeight(), ARGB_8888);
 


### PR DESCRIPTION
This usually means that the test has moved on to another activity and the one passed in is no longer being displayed. This will hopefully help others who get here and then experience a RTE when Bitmap tries to create a bitmap with either no height or no width.

`mvn clean verify` results:

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] Spoon (Parent) ..................................... SUCCESS [  0.783 s]
[INFO] Spoon Client Library ............................... SUCCESS [  2.190 s]
[INFO] Spoon Runner ....................................... SUCCESS [  6.702 s]
[INFO] Spoon Maven Plugin ................................. SUCCESS [  1.954 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11.767 s
[INFO] Finished at: 2016-08-31T17:40:16-04:00
[INFO] Final Memory: 45M/801M
[INFO] ------------------------------------------------------------------------
```