### PR TITLE
Fixed Html rendering when running on Windows

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -1,0 +1,84 @@
+@if "%DEBUG%" == "" @echo off
+@rem ##########################################################################
+@rem
+@rem  Gradle startup script for Windows
+@rem
+@rem ##########################################################################
+
+@rem Set local scope for the variables with windows NT shell
+if "%OS%"=="Windows_NT" setlocal
+
+set DIRNAME=%~dp0
+if "%DIRNAME%" == "" set DIRNAME=.
+set APP_BASE_NAME=%~n0
+set APP_HOME=%DIRNAME%
+
+@rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+set DEFAULT_JVM_OPTS=
+
+@rem Find java.exe
+if defined JAVA_HOME goto findJavaFromJavaHome
+
+set JAVA_EXE=java.exe
+%JAVA_EXE% -version >NUL 2>&1
+if "%ERRORLEVEL%" == "0" goto init
+
+echo.
+echo ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:findJavaFromJavaHome
+set JAVA_HOME=%JAVA_HOME:"=%
+set JAVA_EXE=%JAVA_HOME%/bin/java.exe
+
+if exist "%JAVA_EXE%" goto init
+
+echo.
+echo ERROR: JAVA_HOME is set to an invalid directory: %JAVA_HOME%
+echo.
+echo Please set the JAVA_HOME variable in your environment to match the
+echo location of your Java installation.
+
+goto fail
+
+:init
+@rem Get command-line arguments, handling Windows variants
+
+if not "%OS%" == "Windows_NT" goto win9xME_args
+
+:win9xME_args
+@rem Slurp the command line arguments.
+set CMD_LINE_ARGS=
+set _SKIP=2
+
+:win9xME_args_slurp
+if "x%~1" == "x" goto execute
+
+set CMD_LINE_ARGS=%*
+
+:execute
+@rem Setup the command line
+
+set CLASSPATH=%APP_HOME%\gradle\wrapper\gradle-wrapper.jar
+
+@rem Execute Gradle
+"%JAVA_EXE%" %DEFAULT_JVM_OPTS% %JAVA_OPTS% %GRADLE_OPTS% "-Dorg.gradle.appname=%APP_BASE_NAME%" -classpath "%CLASSPATH%" org.gradle.wrapper.GradleWrapperMain %CMD_LINE_ARGS%
+
+:end
+@rem End local scope for the variables with windows NT shell
+if "%ERRORLEVEL%"=="0" goto mainEnd
+
+:fail
+rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
+rem the _cmd.exe /c_ return code!
+if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+exit /b 1
+
+:mainEnd
+if "%OS%"=="Windows_NT" endlocal
+
+:omega

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlRenderer.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlRenderer.java
@@ -1,5 +1,7 @@
 package com.squareup.spoon.html;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.github.mustachejava.DefaultMustacheFactory;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheFactory;
@@ -12,18 +14,17 @@ import com.squareup.spoon.DeviceTestResult;
 import com.squareup.spoon.SpoonSummary;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.lesscss.LessCompiler;
-
-import static com.google.common.base.Charsets.UTF_8;
 
 /** Renders a {@link com.squareup.spoon.SpoonSummary} as static HTML to an output directory. */
 public final class HtmlRenderer {
@@ -62,7 +63,7 @@ public final class HtmlRenderer {
 
   private void copyStaticAssets() {
     File statics = new File(output, STATIC_DIRECTORY);
-    statics.mkdir();
+    statics.mkdirs();
     for (String staticAsset : STATIC_ASSETS) {
       copyStaticToOutput(staticAsset, statics);
     }
@@ -74,21 +75,17 @@ public final class HtmlRenderer {
       String less = Resources.toString(getClass().getResource("/spoon.less"), UTF_8);
       String css = compiler.compile(less);
       File cssFile = FileUtils.getFile(output, STATIC_DIRECTORY, "spoon.css");
-      FileUtils.writeStringToFile(cssFile, css);
+      FileUtils.writeStringToFile(cssFile, css, UTF_8);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }
 
   private void writeResultJson() {
-    FileWriter result = null;
-    try {
-      result = new FileWriter(new File(output, "result.json"));
+    try (Writer result = new PrintWriter(new File(output, "result.json"), "UTF-8")) {
       gson.toJson(summary, result);
     } catch (IOException e) {
       throw new RuntimeException("Unable to write result.json file.", e);
-    } finally {
-      IOUtils.closeQuietly(result);
     }
   }
 
@@ -150,15 +147,11 @@ public final class HtmlRenderer {
   }
 
   private static void renderMustacheToFile(Mustache mustache, Object scope, File file) {
-    FileWriter writer = null;
-    try {
-      file.getParentFile().mkdirs();
-      writer = new FileWriter(file);
+    file.getParentFile().mkdirs();
+    try (Writer writer = new PrintWriter(file, "UTF-8")) {
       mustache.execute(writer, scope);
     } catch (IOException e) {
       throw new RuntimeException(e);
-    } finally {
-      IOUtils.closeQuietly(writer);
     }
   }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlRenderer.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlRenderer.java
@@ -12,12 +12,13 @@ import com.squareup.spoon.DeviceResult;
 import com.squareup.spoon.DeviceTest;
 import com.squareup.spoon.DeviceTestResult;
 import com.squareup.spoon.SpoonSummary;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.PrintWriter;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -82,7 +83,8 @@ public final class HtmlRenderer {
   }
 
   private void writeResultJson() {
-    try (Writer result = new PrintWriter(new File(output, "result.json"), "UTF-8")) {
+    try (Writer result = new BufferedWriter(
+        new OutputStreamWriter(new FileOutputStream(new File(output, "result.json")), UTF_8))) {
       gson.toJson(summary, result);
     } catch (IOException e) {
       throw new RuntimeException("Unable to write result.json file.", e);
@@ -148,7 +150,8 @@ public final class HtmlRenderer {
 
   private static void renderMustacheToFile(Mustache mustache, Object scope, File file) {
     file.getParentFile().mkdirs();
-    try (Writer writer = new PrintWriter(file, "UTF-8")) {
+    try (Writer writer = new BufferedWriter(
+        new OutputStreamWriter(new FileOutputStream(file), UTF_8))) {
       mustache.execute(writer, scope);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonHtmlRendererTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonHtmlRendererTest.java
@@ -20,6 +20,7 @@ import org.junit.rules.TemporaryFolder;
 public final class SpoonHtmlRendererTest {
 
   private static final String SPOON_IN_RUSSIAN = "\u041B\u043E\u0436\u043A\u0430";
+  private static final String[] FILE_EXTENSIONS_TO_CHECK = {"html", "css", "json", "js"};
 
   @Rule
   public TemporaryFolder testFolder = new TemporaryFolder();
@@ -35,10 +36,9 @@ public final class SpoonHtmlRendererTest {
     htmlRenderer.render();
 
     setDefaultCharset(StandardCharsets.US_ASCII);
-
-    Iterator<File> it = FileUtils
-        .iterateFiles(folder, new String[]{"html", "css", "json", "js"}, true);
+    Iterator<File> it = FileUtils.iterateFiles(folder, FILE_EXTENSIONS_TO_CHECK, true);
     File nextFile = null;
+
     try {
       while (it.hasNext()) {
         nextFile = it.next();

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonHtmlRendererTest.java
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonHtmlRendererTest.java
@@ -1,0 +1,89 @@
+package com.squareup.spoon;
+
+import com.squareup.spoon.html.HtmlRenderer;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.MalformedInputException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import org.apache.commons.io.FileUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public final class SpoonHtmlRendererTest {
+
+  private static final String SPOON_IN_RUSSIAN = "\u041B\u043E\u0436\u043A\u0430";
+
+  @Rule
+  public TemporaryFolder testFolder = new TemporaryFolder();
+
+  @Test
+  public void correctRenderingOfNonLatinCharacters() throws IOException {
+
+    SpoonSummary summary = prepareNonLatinSummary();
+    File folder = testFolder.getRoot();
+    CharsetDecoder utf8Decoder = StandardCharsets.UTF_8.newDecoder();
+
+    HtmlRenderer htmlRenderer = new HtmlRenderer(summary, SpoonUtils.GSON, folder);
+    htmlRenderer.render();
+
+    setDefaultCharset(StandardCharsets.US_ASCII);
+
+    Iterator<File> it = FileUtils
+        .iterateFiles(folder, new String[]{"html", "css", "json", "js"}, true);
+    File nextFile = null;
+    try {
+      while (it.hasNext()) {
+        nextFile = it.next();
+        decode(nextFile, utf8Decoder);
+      }
+    } catch (MalformedInputException ex) {
+      throw new IllegalStateException(String.format("Found wrong file [%s]", nextFile.getName()));
+    } finally {
+      setDefaultCharset(null);
+    }
+  }
+
+  private SpoonSummary prepareNonLatinSummary() {
+    DeviceTest device = new DeviceTest("foo", "bar");
+    return new SpoonSummary.Builder() //
+        .setTitle(SPOON_IN_RUSSIAN) //
+        .start() //
+        .addResult(SPOON_IN_RUSSIAN, new DeviceResult.Builder().startTests() //
+            .addTestResultBuilder(device, new DeviceTestResult.Builder() //
+                .startTest() //
+                .markTestAsFailed(SPOON_IN_RUSSIAN).endTest()) //
+            .addException(new RuntimeException(SPOON_IN_RUSSIAN)) //
+            .build()) //
+        .end() //
+        .build();
+  }
+
+  private void setDefaultCharset(Charset value) {
+    Field charset;
+    try {
+      charset = Charset.class.getDeclaredField("defaultCharset");
+      charset.setAccessible(true);
+      charset.set(null, value);
+    } catch (NoSuchFieldException | IllegalAccessException ignored) {
+    }
+  }
+
+  private void decode(File file, CharsetDecoder charsetDecoder) throws IOException {
+    try (FileInputStream fis = new FileInputStream(file)) {
+      FileChannel fileChannel = fis.getChannel();
+      ByteBuffer buffer = ByteBuffer.allocate((int) fileChannel.size());
+      fileChannel.read(buffer);
+      buffer.rewind();
+      charsetDecoder.decode(buffer);
+    }
+  }
+
+}


### PR DESCRIPTION
In Windows Charset.getDefault() returns CP1251 instead of UTF-8, so we always need to use Writers and Readers with explicitly defined UTF-8 charset. Espresso prints text of UI element when withText() assertion fails, but it was unreadable in report.