### PR TITLE
Set the main class name in the jar.

### DIFF
--- a/spoon-runner/build.gradle
+++ b/spoon-runner/build.gradle
@@ -1,5 +1,8 @@
 apply plugin: 'java'
+apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
+
+mainClassName = 'com.squareup.spoon.SpoonRunner'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
This allows the runner to be used from the command line.

```
$ ./gradlew build

$ java -jar spoon-runner/build/libs/spoon-runner-2.0.0-SNAPSHOT-all.jar --help
Usage: <main class> [options]
  Options:
        --adb-timeout
       Set maximum execution time per test in seconds (10min default)
       Default: 600
  *     --apk
       Application APK
        --class-name
       Test class name to run (fully-qualified)
        --coverage
       Code coverage flag
       Default: false
        --e
       Arguments to pass to the Instrumentation Runner. This can be used
       multiple times for multiple entries. Usage: --e <NAME>=<VALUE>.
        --fail-if-no-device-connected
       Fail if no device is connected
       Default: false
        --fail-on-failure
       Non-zero exit code on failure
       Default: false
        --grant-all
       Grant all runtime permissions during installation on Marshmallow and
       above devices
       Default: false
        --init-script
       Script file executed between each devices
        --method-name
       Test method name to run (must also use --class-name)
        --no-animations
       Disable animated gif generation
       Default: false
        --output
       Output path
       Default: spoon-output
        --sdk
       Path to Android SDK
       Default: /Users/jw/android-sdk
        --sequential
       Execute tests sequentially (one device at a time)
       Default: false
        --shard
       Automatically shard across all specified serials
       Default: false
        --size
       Only run methods with corresponding size annotation (small, medium,
       large)
  *     --test-apk
       Test application APK
        --title
       Execution title
       Default: Spoon Execution
    -serial
       Serial of the device to use (May be used multiple times)
       Default: []
    -skipDevices
       Serial of the device to skip (May be used multiple times)
       Default: []
```

Closes #431.