### PR TITLE
Updated Checkstyle version to 7.6.1, fixed violations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,8 @@ subprojects { project ->
   }
 
   apply plugin: 'checkstyle'
-  tasks.withType(Checkstyle) {
+  project.checkstyle {
+    toolVersion "7.6.1"
     configFile rootProject.file('checkstyle.xml')
   }
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -108,7 +108,6 @@
     <!--<module name="InnerAssignment"/>-->
     <!--module name="MagicNumber"/-->
     <module name="MissingSwitchDefault"/>
-    <module name="RedundantThrows"/>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonCoverageMerger.java
@@ -17,7 +17,7 @@ final class SpoonCoverageMerger {
   private static final String MERGED_COVERAGE_FILE = "merged-coverage.ec";
   private ExecFileLoader execFileLoader;
 
-  public SpoonCoverageMerger() {
+  SpoonCoverageMerger() {
     this.execFileLoader = new ExecFileLoader();
   }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceLogger.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceLogger.java
@@ -19,7 +19,7 @@ final class SpoonDeviceLogger implements LogCatListener {
   private final List<LogCatMessage> messages;
   private final LogCatReceiverTask logCatReceiverTask;
 
-  public SpoonDeviceLogger(IDevice device) {
+  SpoonDeviceLogger(IDevice device) {
     messages = new ArrayList<>();
     logCatReceiverTask = new LogCatReceiverTask(device);
     logCatReceiverTask.addLogCatListener(this);


### PR DESCRIPTION
* Disable deprecated RedundantThrows check (it was already removed in 6.2) to be able to use Checkstyle IDEA plugin
* Updated Checkstyle version to 7.6.1
* Fixed Checkstyle violations