### PR TITLE
Port CLI parsing and main function to Kotlin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,12 +5,13 @@ buildscript {
       'buildTools': '25.0.2',
 
       'supportLibrary': '25.3.1',
+      'kotlin': '1.1.1',
       'errorProne': '2.0.19',
   ]
 
   ext.deps = [
       'gson': 'com.google.code.gson:gson:2.8.0',
-      'jcommander': 'com.beust:jcommander:1.35',
+      'argparser': 'com.xenomachina:kotlin-argparser:1.1.0',
       'commonsLang3': 'org.apache.commons:commons-lang3:3.3.1',
       'commonsIo': 'commons-io:commons-io:2.5',
       'ddmlib': 'com.android.tools.ddms:ddmlib:25.3.0',
@@ -23,6 +24,7 @@ buildscript {
           'runtime': 'com.jakewharton:butterknife:8.5.1',
           'compiler': 'com.jakewharton:butterknife-compiler:8.5.1'
       ],
+      'kotlinStdLibJre8': "org.jetbrains.kotlin:kotlin-stdlib-jre8:${versions.kotlin}",
 
       'junit': 'junit:junit:4.12',
       'truth': 'com.google.truth:truth:0.31',
@@ -46,6 +48,7 @@ buildscript {
     classpath 'com.android.tools.build:gradle:2.3.0'
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.8'
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
   }
 
   repositories {

--- a/spoon-runner/build.gradle
+++ b/spoon-runner/build.gradle
@@ -1,16 +1,28 @@
 apply plugin: 'java'
+apply plugin: 'kotlin'
 apply plugin: 'application'
 apply plugin: 'com.github.johnrengelman.shadow'
 
-mainClassName = 'com.squareup.spoon.SpoonRunner'
+mainClassName = 'com.squareup.spoon.Main'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
+compileKotlin {
+  sourceCompatibility = JavaVersion.VERSION_1_8
+  targetCompatibility = JavaVersion.VERSION_1_8
+
+  kotlinOptions {
+    jvmTarget = '1.8'
+    apiVersion = '1.1'
+    languageVersion = '1.1'
+  }
+}
+
 dependencies {
   compile project(':spoon-common')
   compile project(':third-party:axmlparser')
-  compile deps.jcommander
+  compile deps.argparser
   compile deps.gson
   compile deps.commonsLang3
   compile deps.commonsIo
@@ -19,6 +31,7 @@ dependencies {
   compile deps.guava
   compile deps.mustache
   compile deps.lesscss
+  compile deps.kotlinStdLibJre8
   compile(deps.jacocoMavenPlugin) {
     exclude group: 'org.apache.maven', module: 'maven-project'
   }

--- a/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
@@ -1,0 +1,70 @@
+package com.squareup.spoon
+
+import com.android.ddmlib.testrunner.IRemoteAndroidTestRunner.TestSize
+import com.xenomachina.argparser.ArgParser
+import java.io.File
+import java.time.Duration
+
+internal class CliArgs(parser: ArgParser) {
+  /* A transform that coerces the normal String type to be nullable. */
+  private val nullableString: String.() -> String? = { this }
+
+  val mainApk by parser.positional("main-apk", help = "Main APKs", transform = ::File)
+
+  val testApk by parser.positional("test-apk", help = "Test APK", transform = ::File)
+
+  val title by parser.storing("Execution title", nullableString).default(null)
+
+  val instrumentationArgs by parser.adding("-e", "--es",
+      help = "Instrumentation runner arguments. Format: key=value")
+
+  val className by parser.storing("--class-name", help = "Fully-qualified test class to run",
+      transform = nullableString).default(null)
+
+  val methodName by parser.storing("--method-name", help = "Method name inside --class-name to run",
+      transform = nullableString).default(null)
+
+  val size by parser.mapping<TestSize?>(
+      "--small" to TestSize.SMALL,
+      "--medium" to TestSize.MEDIUM,
+      "--large" to TestSize.LARGE,
+      help = "Test size to run")
+      .default(null)
+
+  val output by parser.storing<File?>(
+      "Output path. Defaults to spoon-output/ in the working directory if unset", ::File).default(
+      null)
+
+  val sdk by parser.storing<File?>("Android SDK path. Defaults to ANDROID_HOME if unset.",
+      ::File).default(null)
+
+  val failOnFailure by parser.flagging("--fail-on-failure", help = "Non-zero exit code on failure")
+
+  val failIfNoDevices by parser.flagging("--fail-if-no-devices",
+      help = "Fail if no devices connected")
+
+  val sequential by parser.flagging("Execute tests sequentially (one device at a time)")
+
+  val initScript by parser.storing<File?>("--init-script",
+      help = "Script file executed between each devices", transform = ::File).default(null)
+
+  val grantAll by parser.flagging("--grant-all",
+      help = "Grant all runtime permissions during installation on M+")
+
+  val disableGif by parser.flagging("--disable-gif", help = "Disable GIF generation")
+
+  val adbTimeout by parser.storing<Duration?>("--adb-timeout",
+      help = "Maximum execution time per test. Parsed by java.time.Duration.",
+      transform = Duration::parse).default(null)
+
+  val serials by parser.adding("--serial",
+      help = "Device serials to use. If empty all devices will be used.")
+
+  val skipSerials by parser.adding("--skip-serial", help = "Device serials to skip")
+
+  val shard by parser.flagging("Shard tests across all devices")
+
+  val debug by parser.flagging("Enable debug logging")
+
+  val coverage by parser.flagging("Enable code coverage")
+}

--- a/spoon-runner/src/main/java/com/squareup/spoon/main.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/main.kt
@@ -1,0 +1,35 @@
+@file:JvmName("Main")
+package com.squareup.spoon
+
+import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.runMain
+
+fun main(vararg args: String) {
+  CliArgs(ArgParser(args)).runMain("spoon-runner") {
+    val builder = SpoonRunner.Builder()
+    builder.setApplicationApk(mainApk)
+    builder.setInstrumentationApk(testApk)
+    sdk?.let(builder::setAndroidSdk)
+    title?.let(builder::setTitle)
+    builder.setInstrumentationArgs(instrumentationArgs);
+    className?.let(builder::setClassName)
+    methodName?.let(builder::setMethodName)
+    size?.let(builder::setTestSize)
+    output?.let(builder::setOutputDirectory)
+    builder.setFailIfNoDeviceConnected(failIfNoDevices)
+    builder.setSequential(sequential)
+    initScript?.let(builder::setInitScript)
+    builder.setGrantAll(grantAll)
+    builder.setNoAnimations(disableGif)
+    adbTimeout?.let(builder::setAdbTimeout)
+    serials.forEach { builder.addDevice(it) }
+    skipSerials.forEach { builder.addDevice(it) }
+    builder.setShard(shard)
+    builder.setDebug(debug)
+    builder.setCodeCoverage(coverage)
+
+    if (!builder.build().run() && failOnFailure) {
+      System.exit(1)
+    }
+  }
+}

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -66,12 +66,12 @@ android.testVariants.all { testVariant ->
     }
 
     classpath = configurations.spoon
-    main = 'com.squareup.spoon.SpoonRunner'
+    main = 'com.squareup.spoon.Main'
     args = [
-        '--debug',
-        '--apk', variantOutputs[0].outputFile,
-        '--test-apk', testVariantOutputs[0].outputFile,
+        variantOutputs[0].outputFile,
+        testVariantOutputs[0].outputFile,
         '--output', outputDir,
+        '--debug',
     ]
   }
   task.dependsOn(variantOutputs[0].assemble, testVariantOutputs[0].assemble)


### PR DESCRIPTION
Looks like:
```
$ java -jar spoon-runner/build/libs/spoon-runner-2.0.0-SNAPSHOT-all.jar -h
usage: spoon-runner [-h] main-apk test-apk [--title TITLE] [-e ES]...
                    [--class-name CLASS_NAME] [--method-name METHOD_NAME]
                    [--small] [--output OUTPUT] [--sdk SDK] [--fail-on-failure]
                    [--fail-if-no-devices] [--sequential]
                    [--init-script INIT_SCRIPT] [--grant-all] [--disable-gif]
                    [--adb-timeout ADB_TIMEOUT] [--serial SERIAL]...
                    [--skip-serial SKIP_SERIAL]... [--shard] [--debug]
                    [--coverage]

optional arguments:
  -h, --help              show this help message and exit

  --title TITLE           Execution title

  -e ES, --es ES          Instrumentation runner arguments. Format: key=value

  --class-name CLASS_NA   Fully-qualified test class to run
  ME

  --method-name METHOD_   Method name inside --class-name to run
  NAME

  --small, --medium,      Test size to run
  --large

  --output OUTPUT         Output path. Defaults to spoon-output/ in the
                          working directory if unset

  --sdk SDK               Android SDK path. Defaults to ANDROID_HOME if unset.

  --fail-on-failure       Non-zero exit code on failure

  --fail-if-no-devices    Fail if no devices connected

  --sequential            Execute tests sequentially (one device at a time)

  --init-script INIT_SC   Script file executed between each devices
  RIPT

  --grant-all             Grant all runtime permissions during installation on
                          M+

  --disable-gif           Disable GIF generation

  --adb-timeout ADB_TIM   Maximum execution time per test. Parsed by
  EOUT                    java.time.Duration.

  --serial SERIAL         Device serials to use. If empty all devices will be
                          used.

  --skip-serial SKIP_SE   Device serials to skip
  RIAL

  --shard                 Shard tests across all devices

  --debug                 Enable debug logging

  --coverage              Enable code coverage


positional arguments:
  main-apk                Main APKs

  test-apk                Test APK
```