### PR TITLE
Update argparser to 2.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
   ext.deps = [
       'gson': 'com.google.code.gson:gson:2.8.0',
-      'argparser': 'com.xenomachina:kotlin-argparser:1.1.0',
+      'argparser': 'com.xenomachina:kotlin-argparser:2.0.0',
       'commonsLang3': 'org.apache.commons:commons-lang3:3.3.1',
       'commonsIo': 'commons-io:commons-io:2.5',
       'ddmlib': 'com.android.tools.ddms:ddmlib:25.3.0',

--- a/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
@@ -2,41 +2,40 @@ package com.squareup.spoon
 
 import com.android.ddmlib.testrunner.IRemoteAndroidTestRunner.TestSize
 import com.xenomachina.argparser.ArgParser
+import com.xenomachina.argparser.default
 import java.io.File
 import java.time.Duration
 
 internal class CliArgs(parser: ArgParser) {
-  /* A transform that coerces the normal String type to be nullable. */
-  private val nullableString: String.() -> String? = { this }
+  val mainApk by parser.positional("MAIN_APK", "Main APK", transform = ::File)
 
-  val mainApk by parser.positional("main-apk", help = "Main APKs", transform = ::File)
+  val testApk by parser.positional("TEST_APK", "Test APK", transform = ::File)
 
-  val testApk by parser.positional("test-apk", help = "Test APK", transform = ::File)
+  val title by parser.storing("Execution title").default(null)
 
-  val title by parser.storing("Execution title", nullableString).default(null)
+  val instrumentationArgs by parser.option<List<String>>("-e", "--es",
+      help = "Instrumentation runner arguments.", argNames = listOf("KEY", "VALUE")) { arguments }
+      .default(emptyList())
 
-  val instrumentationArgs by parser.adding("-e", "--es",
-      help = "Instrumentation runner arguments. Format: key=value")
+  val className by parser.storing("--class-name", help = "Fully-qualified test class to run")
+      .default(null)
 
-  val className by parser.storing("--class-name", help = "Fully-qualified test class to run",
-      transform = nullableString).default(null)
+  val methodName by parser.storing("--method-name", help = "Method name inside --class-name to run")
+      .default(null)
 
-  val methodName by parser.storing("--method-name", help = "Method name inside --class-name to run",
-      transform = nullableString).default(null)
-
-  val size by parser.mapping<TestSize?>(
+  val size by parser.mapping(
       "--small" to TestSize.SMALL,
       "--medium" to TestSize.MEDIUM,
       "--large" to TestSize.LARGE,
       help = "Test size to run")
       .default(null)
 
-  val output by parser.storing<File?>(
-      "Output path. Defaults to spoon-output/ in the working directory if unset", ::File).default(
-      null)
+  val output by parser.storing(
+      "Output path. Defaults to spoon-output/ in the working directory if unset",
+      transform = ::File).default(null)
 
-  val sdk by parser.storing<File?>("Android SDK path. Defaults to ANDROID_HOME if unset.",
-      ::File).default(null)
+  val sdk by parser.storing("Android SDK path. Defaults to ANDROID_HOME if unset.",
+      transform = ::File).default(null)
 
   val failOnFailure by parser.flagging("--fail-on-failure", help = "Non-zero exit code on failure")
 
@@ -45,7 +44,7 @@ internal class CliArgs(parser: ArgParser) {
 
   val sequential by parser.flagging("Execute tests sequentially (one device at a time)")
 
-  val initScript by parser.storing<File?>("--init-script",
+  val initScript by parser.storing("--init-script",
       help = "Script file executed between each devices", transform = ::File).default(null)
 
   val grantAll by parser.flagging("--grant-all",
@@ -53,7 +52,7 @@ internal class CliArgs(parser: ArgParser) {
 
   val disableGif by parser.flagging("--disable-gif", help = "Disable GIF generation")
 
-  val adbTimeout by parser.storing<Duration?>("--adb-timeout",
+  val adbTimeout by parser.storing("--adb-timeout",
       help = "Maximum execution time per test. Parsed by java.time.Duration.",
       transform = Duration::parse).default(null)
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/main.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/main.kt
@@ -2,34 +2,36 @@
 package com.squareup.spoon
 
 import com.xenomachina.argparser.ArgParser
-import com.xenomachina.argparser.runMain
+import com.xenomachina.argparser.mainBody
 
 fun main(vararg args: String) {
-  CliArgs(ArgParser(args)).runMain("spoon-runner") {
-    val builder = SpoonRunner.Builder()
-    builder.setApplicationApk(mainApk)
-    builder.setInstrumentationApk(testApk)
-    sdk?.let(builder::setAndroidSdk)
-    title?.let(builder::setTitle)
-    builder.setInstrumentationArgs(instrumentationArgs);
-    className?.let(builder::setClassName)
-    methodName?.let(builder::setMethodName)
-    size?.let(builder::setTestSize)
-    output?.let(builder::setOutputDirectory)
-    builder.setFailIfNoDeviceConnected(failIfNoDevices)
-    builder.setSequential(sequential)
-    initScript?.let(builder::setInitScript)
-    builder.setGrantAll(grantAll)
-    builder.setNoAnimations(disableGif)
-    adbTimeout?.let(builder::setAdbTimeout)
-    serials.forEach { builder.addDevice(it) }
-    skipSerials.forEach { builder.addDevice(it) }
-    builder.setShard(shard)
-    builder.setDebug(debug)
-    builder.setCodeCoverage(coverage)
+  mainBody("spoon-runner") {
+    CliArgs(ArgParser(args)).run {
+      val builder = SpoonRunner.Builder()
+      builder.setApplicationApk(mainApk)
+      builder.setInstrumentationApk(testApk)
+      sdk?.let(builder::setAndroidSdk)
+      title?.let(builder::setTitle)
+      builder.setInstrumentationArgs(instrumentationArgs);
+      className?.let(builder::setClassName)
+      methodName?.let(builder::setMethodName)
+      size?.let(builder::setTestSize)
+      output?.let(builder::setOutputDirectory)
+      builder.setFailIfNoDeviceConnected(failIfNoDevices)
+      builder.setSequential(sequential)
+      initScript?.let(builder::setInitScript)
+      builder.setGrantAll(grantAll)
+      builder.setNoAnimations(disableGif)
+      adbTimeout?.let(builder::setAdbTimeout)
+      serials.forEach { builder.addDevice(it) }
+      skipSerials.forEach { builder.addDevice(it) }
+      builder.setShard(shard)
+      builder.setDebug(debug)
+      builder.setCodeCoverage(coverage)
 
-    if (!builder.build().run() && failOnFailure) {
-      System.exit(1)
+      if (!builder.build().run() && failOnFailure) {
+        System.exit(1)
+      }
     }
   }
 }


### PR DESCRIPTION
This lets us do multi-value args, better nullability, and prettier output.

```
usage: spoon-runner [-h] MAIN_APK TEST_APK [--title TITLE] [-e KEY VALUE]
                    [--class-name CLASS_NAME] [--method-name METHOD_NAME]
                    [--small] [--output OUTPUT] [--sdk SDK] [--fail-on-failure]
                    [--fail-if-no-devices] [--sequential]
                    [--init-script INIT_SCRIPT] [--grant-all] [--disable-gif]
                    [--adb-timeout ADB_TIMEOUT] [--serial SERIAL]...
                    [--skip-serial SKIP_SERIAL]... [--shard] [--debug]
                    [--coverage]

optional arguments:
  -h, --help                  show this help message and exit

  --title TITLE               Execution title

  -e KEY VALUE,               Instrumentation runner arguments.
  --es KEY VALUE

  --class-name CLASS_NAME     Fully-qualified test class to run

  --method-name METHOD_NAME   Method name inside --class-name to run

  --small, --medium, --large  Test size to run

  --output OUTPUT             Output path. Defaults to spoon-output/ in the
                              working directory if unset

  --sdk SDK                   Android SDK path. Defaults to ANDROID_HOME if
                              unset.

  --fail-on-failure           Non-zero exit code on failure

  --fail-if-no-devices        Fail if no devices connected

  --sequential                Execute tests sequentially (one device at a
                              time)

  --init-script INIT_SCRIPT   Script file executed between each devices

  --grant-all                 Grant all runtime permissions during
                              installation on M+

  --disable-gif               Disable GIF generation

  --adb-timeout ADB_TIMEOUT   Maximum execution time per test. Parsed by
                              java.time.Duration.

  --serial SERIAL             Device serials to use. If empty all devices will
                              be used.

  --skip-serial SKIP_SERIAL   Device serials to skip

  --shard                     Shard tests across all devices

  --debug                     Enable debug logging

  --coverage                  Enable code coverage


positional arguments:
  MAIN_APK                    Main APK

  TEST_APK                    Test APK
```