### PR TITLE
Run each test in its own instrumentation call.

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/LogRecordingTestRunListener.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/LogRecordingTestRunListener.kt
@@ -1,0 +1,43 @@
+package com.squareup.spoon
+
+import com.android.ddmlib.testrunner.ITestRunListener
+import com.android.ddmlib.testrunner.TestIdentifier
+import com.google.common.collect.ImmutableList
+import java.util.LinkedHashSet
+
+/**
+ * Listens to an instrumentation invocation where `log=true` is set and records information about
+ * the test suite.
+ */
+internal class LogRecordingTestRunListener : ITestRunListener {
+  private val activeTests = LinkedHashSet<TestIdentifier>()
+  private val ignoredTests = LinkedHashSet<TestIdentifier>()
+  private var runName: String? = null
+  private var testCount: Int = 0
+
+  fun activeTests(): List<TestIdentifier> = ImmutableList.copyOf(activeTests)
+  fun ignoredTests(): List<TestIdentifier> = ImmutableList.copyOf(ignoredTests)
+  fun runName() = runName
+  fun testCount() = testCount
+
+  override fun testRunStarted(runName: String, testCount: Int) {
+    this.runName = runName
+    this.testCount = testCount
+  }
+
+  override fun testStarted(test: TestIdentifier) {
+    activeTests.add(test)
+  }
+
+  override fun testIgnored(test: TestIdentifier) {
+    activeTests.remove(test)
+    ignoredTests.add(test)
+  }
+
+  override fun testFailed(test: TestIdentifier, trace: String) {}
+  override fun testAssumptionFailure(test: TestIdentifier, trace: String) {}
+  override fun testEnded(test: TestIdentifier, testMetrics: Map<String, String>) {}
+  override fun testRunFailed(errorMessage: String) {}
+  override fun testRunStopped(elapsedTime: Long) {}
+  override fun testRunEnded(elapsedTime: Long, runMetrics: Map<String, String>) {}
+}

--- a/spoon-runner/src/main/java/com/squareup/spoon/MultiRunITestListener.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/MultiRunITestListener.kt
@@ -1,0 +1,67 @@
+package com.squareup.spoon
+
+import com.android.ddmlib.testrunner.ITestRunListener
+import com.android.ddmlib.testrunner.TestIdentifier
+import com.google.common.base.Stopwatch
+import java.util.concurrent.TimeUnit.SECONDS
+
+/**
+ * A [ITestRunListener] which delegates to multiple other [ITestRunListener] instances, except
+ * suppressing calls to [ITestRunListener.testRunStarted], [ITestRunListener.testRunEnded], and
+ * [ITestRunListener.testRunStopped]. This allows multiple test runs to be aggregated in the
+ * `delegates` as if they were a single run.
+ */
+internal class MultiRunITestListener(val delegates: List<ITestRunListener>) : ITestRunListener {
+  private val stopwatch = Stopwatch.createUnstarted()
+  private var started = false
+  private var stopped = false
+
+  fun multiRunStarted(runName: String?, testCount: Int) {
+    check(!started) { "Already started" }
+    started = true
+
+    delegates.forEach {
+      it.testRunStarted(runName, testCount)
+    }
+    stopwatch.start()
+  }
+
+  fun multiRunEnded() {
+    check(started) { "Not started" }
+    check(!stopped) { "Already stopped" }
+    stopped = true
+
+    stopwatch.elapsed(SECONDS).let { elapsedTime ->
+      delegates.forEach {
+        it.testRunEnded(elapsedTime, emptyMap())
+      }
+    }
+  }
+
+  override fun testStarted(test: TestIdentifier) {
+    delegates.forEach { it.testStarted(test) }
+  }
+
+  override fun testAssumptionFailure(test: TestIdentifier, trace: String) {
+    delegates.forEach { it.testAssumptionFailure(test, trace) }
+  }
+
+  override fun testFailed(test: TestIdentifier, trace: String) {
+    delegates.forEach { it.testFailed(test, trace) }
+  }
+
+  override fun testEnded(test: TestIdentifier, testMetrics: Map<String, String>) {
+    delegates.forEach { it.testEnded(test, testMetrics) }
+  }
+
+  override fun testIgnored(test: TestIdentifier) {
+    delegates.forEach { it.testIgnored(test) }
+  }
+
+  override fun testRunStarted(runName: String, testCount: Int) {}
+  override fun testRunStopped(elapsedTime: Long) {}
+  override fun testRunEnded(elapsedTime: Long, runMetrics: Map<String, String>) {}
+  override fun testRunFailed(errorMessage: String) {
+    // TODO something!
+  }
+}

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonTestRunListener.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonTestRunListener.java
@@ -28,11 +28,6 @@ final class SpoonTestRunListener implements ITestRunListener {
     });
   }
 
-  @Override public void testRunStarted(String runName, int testCount) {
-    logDebug(debug, "testCount=%d runName=%s", testCount, runName);
-    result.startTests();
-  }
-
   @Override public void testStarted(TestIdentifier test) {
     logDebug(debug, "started %s", test);
     methodResults.put(test, new DeviceTestResult.Builder().startTest());
@@ -58,17 +53,17 @@ final class SpoonTestRunListener implements ITestRunListener {
     result.addTestResultBuilder(DeviceTest.from(test), obtainMethodResult(test).endTest());
   }
 
+  @Override public void testRunStarted(String runName, int testCount) {
+  }
+
   @Override public void testRunFailed(String errorMessage) {
     logDebug(debug, "errorMessage=%s", errorMessage);
     result.addException(errorMessage);
   }
 
   @Override public void testRunStopped(long elapsedTime) {
-    logDebug(debug, "elapsedTime=%d", elapsedTime);
   }
 
   @Override public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
-    logDebug(debug, "elapsedTime=%d", elapsedTime);
-    result.endTests();
   }
 }


### PR DESCRIPTION
This prevents instance state from leaking across tests.

`SpoonDeviceRunner` is still a bit sloppy. Going to work to make it better over time.