### PR TITLE
Add save files ability to SpoonRule.

### DIFF
--- a/spoon-client/src/main/java/com/squareup/spoon/SpoonRule.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/SpoonRule.java
@@ -4,8 +4,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.util.Log;
+
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -23,6 +26,7 @@ import static android.os.Environment.getExternalStorageDirectory;
 import static com.squareup.spoon.Chmod.chmodPlusR;
 import static com.squareup.spoon.Chmod.chmodPlusRWX;
 import static com.squareup.spoon.internal.Constants.NAME_SEPARATOR;
+import static com.squareup.spoon.internal.Constants.SPOON_FILES;
 import static com.squareup.spoon.internal.Constants.SPOON_SCREENSHOTS;
 
 /**
@@ -59,7 +63,7 @@ public final class SpoonRule implements TestRule {
       throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
     }
     File screenshotDirectory =
-        obtainScreenshotDirectory(activity.getApplicationContext(), className, methodName);
+        obtainDirectory(activity.getApplicationContext(), className, methodName, SPOON_SCREENSHOTS);
     String screenshotName = System.currentTimeMillis() + NAME_SEPARATOR + tag + EXTENSION;
     File screenshotFile = new File(screenshotDirectory, screenshotName);
     Bitmap bitmap = Screenshot.capture(tag, activity);
@@ -88,21 +92,70 @@ public final class SpoonRule implements TestRule {
     }
   }
 
-  private static File obtainScreenshotDirectory(Context context, String testClassName,
-      String testMethodName) {
+  private static File obtainDirectory(Context context, String testClassName,
+      String testMethodName, String directoryName) {
     File directory;
     if (SDK_INT >= LOLLIPOP) {
       // Use external storage.
-      directory = new File(getExternalStorageDirectory(), "app_" + SPOON_SCREENSHOTS);
+      directory = new File(getExternalStorageDirectory(), "app_" + directoryName);
     } else {
       // Use internal storage.
-      directory = context.getDir(SPOON_SCREENSHOTS, MODE_WORLD_READABLE);
+      directory = context.getDir(directoryName, MODE_WORLD_READABLE);
     }
 
     File dirClass = new File(directory, testClassName);
     File dirMethod = new File(dirClass, testMethodName);
     createDir(dirMethod);
     return dirMethod;
+  }
+
+
+  public File save(final Context context, final File file) {
+    if (!file.exists()) {
+      throw new RuntimeException("Can't find any file at: " + file);
+    }
+
+    File filesDirectory = null;
+    try {
+      filesDirectory = obtainDirectory(context, className, methodName, SPOON_FILES);
+      File target = new File(filesDirectory, file.getName());
+      copyFile(file, target);
+      Log.d(TAG, "Saved " + file);
+      return target;
+    } catch (IOException e) {
+      throw new RuntimeException("Couldn't copy file " + file + " to " + filesDirectory, e);
+    }
+  }
+
+  private static void copyFile(File source, File target) throws IOException {
+    Log.d(TAG, "Will copy " + source + " to " + target);
+
+    if (!target.createNewFile()) {
+      throw new RuntimeException("Couldn't create file " + target);
+    }
+    chmodPlusR(target);
+
+    BufferedInputStream is = null;
+    BufferedOutputStream os = null;
+    try {
+      is = new BufferedInputStream(new FileInputStream(source));
+      os = new BufferedOutputStream(new FileOutputStream(target));
+      byte[] buffer = new byte[4096];
+      while (true) {
+        int read = is.read(buffer);
+        if (read == -1) {
+          break;
+        }
+        os.write(buffer, 0, read);
+      }
+    } finally {
+      try {
+        is.close();
+      } catch (IOException ie) {}
+      try {
+        os.close();
+      } catch (IOException ie) {}
+    }
   }
 
   private static void createDir(File dir) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -176,11 +176,12 @@ public final class SpoonDeviceRunner {
 
     try {
       cleanScreenshotsDirectoriesOnDevice(device);
+      cleanFilesDirectoriesOnDevice(device);
     } catch (Exception e) {
-      logInfo("Exception while cleaning screenshots storage directories on device [%s]", serial);
+      logInfo("Exception while cleaning storage directories on device [%s]", serial);
       e.printStackTrace(System.out);
       return result.markInstallAsFailed(
-          "Unable to delete screenshots storage directories").addException(e).build();
+          "Unable to delete storage directories").addException(e).build();
     }
 
     try {
@@ -527,6 +528,14 @@ public final class SpoonDeviceRunner {
 
     FileEntry internalScreenShotDir = getDirectoryOnInternalStorage(DEVICE_SCREENSHOT_DIR);
     cleanDirectoryOnDevice(internalScreenShotDir.getFullPath(), device);
+  }
+
+  private void cleanFilesDirectoriesOnDevice(IDevice device) throws Exception {
+    FileEntry externalFileDir = getDirectoryOnExternalStorage(device, DEVICE_FILE_DIR);
+    cleanDirectoryOnDevice(externalFileDir.getFullPath(), device);
+
+    FileEntry internalFileDir = getDirectoryOnInternalStorage(DEVICE_FILE_DIR);
+    cleanDirectoryOnDevice(internalFileDir.getFullPath(), device);
   }
 
   private void cleanDirectoryOnDevice(String fullPath, IDevice device) throws Exception {


### PR DESCRIPTION
As discussed in #465

Basically just copied over code from old `Spoon.java` implementation w/ minor changes to `SpoonRule`, and clear files from each device at the start of testing.

Question: Should the code in `SpoonRule` have tests?  I see we don't have Mockito or PowerMock so it would be difficult unless we move androidy stuff out to separate classes.