### PR TITLE
Fix skipping devices

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -91,9 +91,6 @@ public final class SpoonRunner {
     } else {
       this.threadExecutor = Executors.newCachedThreadPool();
     }
-    if (this.skipDevices != null && !this.skipDevices.isEmpty()) {
-      serials.removeAll(this.skipDevices);
-    }
     this.serials = ImmutableSet.copyOf(serials);
   }
 
@@ -117,6 +114,10 @@ public final class SpoonRunner {
       Set<String> serials = this.serials;
       if (serials.isEmpty()) {
         serials = SpoonUtils.findAllDevices(adb, testInfo.getMinSdkVersion());
+      }
+      if (this.skipDevices != null && !this.skipDevices.isEmpty()) {
+        serials = new LinkedHashSet<>(serials);
+        serials.removeAll(this.skipDevices);
       }
       if (serials.isEmpty() && !allowNoDevices) {
         throw new RuntimeException("No device(s) found.");

--- a/spoon-runner/src/main/java/com/squareup/spoon/main.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/main.kt
@@ -26,7 +26,7 @@ fun main(vararg args: String) {
     setNoAnimations(cli.disableGif)
     cli.adbTimeout?.let(this::setAdbTimeout)
     cli.serials.forEach { addDevice(it) }
-    cli.skipSerials.forEach { addDevice(it) }
+    cli.skipSerials.forEach { skipDevice(it) }
     setShard(cli.shard)
     setDebug(cli.debug)
     setCodeCoverage(cli.coverage)


### PR DESCRIPTION
Fixes bug where the `--skip-serial` arguments would only be applied if you also used the `--serial` argument. The device filtering was moved from the `SpoonRunner` constructor to the `run()` method, so the filter can be applied correctly even when Spoon uses ADB to get the list of device serials.

Partially reverts the changes in #480, but I tried to make sure the set of serials is mutable before removing skipped devices.