### PR TITLE
Add option to run all tests in single instrumentation call

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
@@ -70,6 +70,9 @@ internal class CliArgs(parser: ArgParser) {
 
   val coverage by parser.flagging("Enable code coverage")
 
+  val singleInstrumentationCall by parser.flagging("--single-instrumentation-call",
+      help = "Run all tests in a single instrumentation call")
+
   init {
     parser.force()
   }

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -213,8 +213,8 @@ public final class SpoonDeviceRunner {
       logDebug(debug, "Ignored tests: %s", ignoredTests);
     } catch (Exception e) {
       return result
-              .addException(e)
-              .build();
+          .addException(e)
+          .build();
     }
 
     // Initiate device logging.

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -1,5 +1,6 @@
 package com.squareup.spoon;
 
+import com.android.annotations.Nullable;
 import com.android.ddmlib.AndroidDebugBridge;
 import com.android.ddmlib.CollectingOutputReceiver;
 import com.android.ddmlib.DdmPreferences;
@@ -70,7 +71,8 @@ public final class SpoonDeviceRunner {
   private final File coverageDir;
   private final File fileDir;
   private final SpoonInstrumentationInfo instrumentationInfo;
-  private boolean codeCoverage;
+  private final boolean codeCoverage;
+  private final boolean singleInstrumentationCall;
   private final List<ITestRunListener> testRunListeners;
   private final boolean grantAll;
 
@@ -93,7 +95,8 @@ public final class SpoonDeviceRunner {
       int numShards, boolean debug, boolean noAnimations, Duration adbTimeout,
       SpoonInstrumentationInfo instrumentationInfo, List<String> instrumentationArgs,
       String className, String methodName, IRemoteAndroidTestRunner.TestSize testSize,
-      List<ITestRunListener> testRunListeners, boolean codeCoverage, boolean grantAll) {
+      List<ITestRunListener> testRunListeners, boolean codeCoverage, boolean grantAll,
+      boolean singleInstrumentationCall) {
     this.testApk = testApk;
     this.otherApks = otherApks;
     this.serial = serial;
@@ -108,6 +111,7 @@ public final class SpoonDeviceRunner {
     this.testSize = testSize;
     this.instrumentationInfo = instrumentationInfo;
     this.codeCoverage = codeCoverage;
+    this.singleInstrumentationCall = singleInstrumentationCall;
     serial = SpoonUtils.sanitizeSerial(serial);
     this.work = FileUtils.getFile(output, TEMP_DIR, serial);
     this.junitReport = FileUtils.getFile(output, JUNIT_DIR, serial + ".xml");
@@ -197,32 +201,21 @@ public final class SpoonDeviceRunner {
     // Create the output directory, if it does not already exist.
     work.mkdirs();
 
-    LogRecordingTestRunListener recorder = new LogRecordingTestRunListener();
+    // determine the test set that is applicable for this device
+    LogRecordingTestRunListener recorder;
+    List<TestIdentifier> activeTests;
+    List<TestIdentifier> ignoredTests;
     try {
-      logDebug(debug, "Querying a list of tests on [%s]", serial);
-      RemoteAndroidTestRunner runner = createConfiguredRunner(testPackage, testRunner, device);
-      runner.addBooleanArg("log", true);
-      // Add the sharding instrumentation arguments if necessary
-      if (numShards != 0) {
-        addShardingInstrumentationArgs(runner);
-      }
-      if (!isNullOrEmpty(className)) {
-        if (isNullOrEmpty(methodName)) {
-          runner.setClassName(className);
-        } else {
-          runner.setMethodName(className, methodName);
-        }
-      }
-      if (testSize != null) {
-        runner.setTestSize(testSize);
-      }
-      runner.run(recorder);
+      recorder = queryTestSet(testPackage, testRunner, device);
+      activeTests = recorder.activeTests();
+      ignoredTests = recorder.ignoredTests();
+      logDebug(debug, "Active tests: %s", activeTests);
+      logDebug(debug, "Ignored tests: %s", ignoredTests);
     } catch (Exception e) {
+      return result
+              .addException(e)
+              .build();
     }
-    List<TestIdentifier> activeTests = recorder.activeTests();
-    List<TestIdentifier> ignoredTests = recorder.ignoredTests();
-    logDebug(debug, "Active tests: %s", activeTests);
-    logDebug(debug, "Ignored tests: %s", ignoredTests);
 
     // Initiate device logging.
     SpoonDeviceLogger deviceLogger = new SpoonDeviceLogger(device);
@@ -237,24 +230,26 @@ public final class SpoonDeviceRunner {
 
     result.startTests();
     multiRunListener.multiRunStarted(recorder.runName(), recorder.testCount());
-    for (TestIdentifier test : activeTests) {
-      logDebug(debug, "Running %s [%s]", test, serial);
+    if (singleInstrumentationCall) {
+      logDebug(debug, "Running all tests in a single instrumentation call [%s]", serial);
       try {
-        RemoteAndroidTestRunner runner = createConfiguredRunner(testPackage, testRunner, device);
-        if (codeCoverage) {
-          addCodeCoverageInstrumentationArgs(runner, device);
-        }
-        runner.setMethodName(test.getClassName(), test.getTestName());
-        runner.run(listeners);
+        runAllTestOnDevice(testPackage, testRunner, device, listeners);
       } catch (Exception e) {
         result.addException(e);
-        break;
       }
-    }
-    for (TestIdentifier ignoredTest : ignoredTests) {
-      multiRunListener.testStarted(ignoredTest);
-      multiRunListener.testIgnored(ignoredTest);
-      multiRunListener.testEnded(ignoredTest, emptyMap());
+    } else {
+      for (TestIdentifier test : activeTests) {
+        try {
+          runTestOnDevice(testPackage, testRunner, device, listeners, test);
+        } catch (Exception e) {
+          result.addException(e);
+        }
+      }
+      for (TestIdentifier ignoredTest : ignoredTests) {
+        multiRunListener.testStarted(ignoredTest);
+        multiRunListener.testIgnored(ignoredTest);
+        multiRunListener.testEnded(ignoredTest, emptyMap());
+      }
     }
     multiRunListener.multiRunEnded();
     result.endTests();
@@ -292,6 +287,56 @@ public final class SpoonDeviceRunner {
               "pm grant " + appPackage + " android.permission.WRITE_EXTERNAL_STORAGE",
               grantOutputReceiver);
     }
+  }
+
+  private LogRecordingTestRunListener queryTestSet(final String testPackage,
+      final String testRunner, final IDevice device) throws Exception {
+
+    LogRecordingTestRunListener recorder = new LogRecordingTestRunListener();
+    logDebug(debug, "Querying a list of tests on [%s]", serial);
+    RemoteAndroidTestRunner runner = createConfiguredRunner(testPackage, testRunner, device);
+    runner.addBooleanArg("log", true);
+    // Add the sharding instrumentation arguments if necessary
+    if (numShards != 0) {
+      addShardingInstrumentationArgs(runner);
+    }
+    if (!isNullOrEmpty(className)) {
+      if (isNullOrEmpty(methodName)) {
+        runner.setClassName(className);
+      } else {
+        runner.setMethodName(className, methodName);
+      }
+    }
+    if (testSize != null) {
+      runner.setTestSize(testSize);
+    }
+    runner.run(recorder);
+    return recorder;
+  }
+
+  private void runAllTestOnDevice(final String testPackage, final String testRunner,
+      final IDevice device, final List<ITestRunListener> listeners) throws Exception {
+
+    runTestOnDevice(testPackage, testRunner, device, listeners, null);
+  }
+
+  private void runTestOnDevice(final String testPackage, final String testRunner,
+      final IDevice device, final List<ITestRunListener> listeners,
+      @Nullable final TestIdentifier test) throws Exception {
+
+    if (test != null) {
+      logDebug(debug, "Running %s [%s]", test, serial);
+    } else {
+      logDebug(debug, "Running tests [%s]", serial);
+    }
+    RemoteAndroidTestRunner runner = createConfiguredRunner(testPackage, testRunner, device);
+    if (codeCoverage) {
+      addCodeCoverageInstrumentationArgs(runner, device);
+    }
+    if (test != null) {
+      runner.setMethodName(test.getClassName(), test.getTestName());
+    }
+    runner.run(listeners);
   }
 
   private RemoteAndroidTestRunner createConfiguredRunner(String testPackage, String testRunner,

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -201,7 +201,7 @@ public final class SpoonDeviceRunner {
     // Create the output directory, if it does not already exist.
     work.mkdirs();
 
-    // determine the test set that is applicable for this device
+    // Determine the test set that is applicable for this device.
     LogRecordingTestRunListener recorder;
     List<TestIdentifier> activeTests;
     List<TestIdentifier> ignoredTests;

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -58,13 +58,15 @@ public final class SpoonRunner {
   private final boolean terminateAdb;
   private File initScript;
   private final boolean grantAll;
+  private final boolean singleInstrumentationCall;
 
   private SpoonRunner(String title, File androidSdk, File testApk, List<File> otherApks,
       File output, boolean debug, boolean noAnimations, Duration adbTimeout, Set<String> serials,
       Set<String> skipDevices, boolean shard, List<String> instrumentationArgs, String className,
       String methodName, IRemoteAndroidTestRunner.TestSize testSize, boolean allowNoDevices,
       List<ITestRunListener> testRunListeners, boolean sequential, File initScript,
-      boolean grantAll, boolean terminateAdb, boolean codeCoverage) {
+      boolean grantAll, boolean terminateAdb, boolean codeCoverage,
+      boolean singleInstrumentationCall) {
     this.title = title;
     this.androidSdk = androidSdk;
     this.otherApks = otherApks;
@@ -85,6 +87,7 @@ public final class SpoonRunner {
     this.terminateAdb = terminateAdb;
     this.initScript = initScript;
     this.grantAll = grantAll;
+    this.singleInstrumentationCall = singleInstrumentationCall;
 
     if (sequential) {
       this.threadExecutor = Executors.newSingleThreadExecutor();
@@ -285,7 +288,7 @@ public final class SpoonRunner {
       SpoonInstrumentationInfo testInfo) {
     return new SpoonDeviceRunner(testApk, otherApks, output, serial, shardIndex, numShards, debug,
         noAnimations, adbTimeout, testInfo, instrumentationArgs, className, methodName, testSize,
-        testRunListeners, codeCoverage, grantAll);
+        testRunListeners, codeCoverage, grantAll, singleInstrumentationCall);
   }
 
   /** Build a test suite for the specified devices and configuration. */
@@ -312,6 +315,7 @@ public final class SpoonRunner {
     private boolean terminateAdb = true;
     private boolean codeCoverage;
     private boolean shard = false;
+    private boolean singleInstrumentationCall = false;
 
     /** Identifying title for this execution. */
     public Builder setTitle(String title) {
@@ -448,6 +452,11 @@ public final class SpoonRunner {
       return this;
     }
 
+    public Builder setSingleInstrumentationCall(boolean singleInstrumentationCall) {
+      this.singleInstrumentationCall = singleInstrumentationCall;
+      return this;
+    }
+
     public SpoonRunner build() {
       checkNotNull(androidSdk, "SDK is required.");
       checkArgument(androidSdk.exists(), "SDK path does not exist.");
@@ -461,7 +470,7 @@ public final class SpoonRunner {
       return new SpoonRunner(title, androidSdk, testApk, otherApks, output, debug, noAnimations,
           adbTimeout, serials, skipDevices, shard, instrumentationArgs, className, methodName,
           testSize, allowNoDevices, testRunListeners, sequential, initScript, grantAll,
-          terminateAdb, codeCoverage);
+          terminateAdb, codeCoverage, singleInstrumentationCall);
     }
   }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/main.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/main.kt
@@ -30,6 +30,7 @@ fun main(vararg args: String) {
     setShard(cli.shard)
     setDebug(cli.debug)
     setCodeCoverage(cli.coverage)
+    setSingleInstrumentationCall(cli.singleInstrumentationCall)
   }.build()
 
   if (!runner.run() && !cli.alwaysZero) {


### PR DESCRIPTION
Running all tests in separate instrumentation calls can lead to significant increase in the
overall runtime of the test set. This adds a `--single-instrumentation-call` flag to make
the spoon runner run all tests in a single call, similar to the behavior in Spoon v1.x.

Related to #456.