### PR TITLE
Running tests from a shard in a single instrumentation call

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
@@ -75,7 +75,8 @@ internal class CliArgs(parser: ArgParser) {
   val coverage by parser.flagging("Enable code coverage")
 
   val singleInstrumentationCall by parser.flagging("--single-instrumentation-call",
-      help = "Run all tests in a single instrumentation call")
+      help = "Run tests in a single instrumentation call. If sharding is enabled each shard " +
+              "will be in a single instrumentation call otherwise all tests will be run.")
 
   private fun validateInstrumentationArgs() {
     val isTestRunPackageLimited = instrumentationArgs?.contains("package") ?: false


### PR DESCRIPTION
Running tests from a shard in a single instrumentation call, connected to issue [509](https://github.com/square/spoon/issues/509) 