### PR TITLE
[spoon-runner] Add video recording support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Options:
     --fail-if-no-device-connected Fail if no device is connected
     --sequential        Execute the tests device by device
     --init-script       Path to a script that you want to run before each device
+    --disable-gif       Disable GIF generation
+    --record-video      Record device screen video
+    --disable-combined-video Disable combining multiple videos into one
     --grant-all         Grant all runtime permissions during installation on Marshmallow and above devices
     --e                 Arguments to pass to the Instrumentation Runner. This can be used
                         multiple times for multiple entries. Usage: --e <NAME>=<VALUE>.

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ buildscript {
   ]
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0-beta7'
+    classpath 'com.android.tools.build:gradle:3.0.1'
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
     classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.10'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ buildscript {
       'commonsIo': 'commons-io:commons-io:2.5',
       'ddmlib': 'com.android.tools.ddms:ddmlib:25.3.0',
       'animatedGifLib': 'com.madgag:animated-gif-lib:1.2',
+      'isoParser': 'com.googlecode.mp4parser:isoparser:1.1.22',
       'guava': 'com.google.guava:guava:21.0',
       'lesscss': 'org.lesscss:lesscss:1.3.3',
       'mustache': 'com.github.spullara.mustache.java:compiler:0.8.14',

--- a/spoon-common/src/main/java/com/squareup/spoon/internal/Constants.java
+++ b/spoon-common/src/main/java/com/squareup/spoon/internal/Constants.java
@@ -2,6 +2,7 @@ package com.squareup.spoon.internal;
 
 public interface Constants {
   String SPOON_SCREENSHOTS = "spoon-screenshots";
+  String SPOON_VIDEOS = "spoon-videos";
   String SPOON_FILES = "spoon-files";
   String NAME_SEPARATOR = "_";
 }

--- a/spoon-runner/build.gradle
+++ b/spoon-runner/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   compile deps.commonsIo
   compile deps.ddmlib
   compile deps.animatedGifLib
+  compile deps.isoParser
   compile deps.guava
   compile deps.mustache
   compile deps.lesscss

--- a/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/CliArgs.kt
@@ -59,6 +59,11 @@ internal class CliArgs(parser: ArgParser) {
 
   val disableGif by parser.flagging("--disable-gif", help = "Disable GIF generation")
 
+  val recordVideo by parser.flagging("--record-video", help = "Record device screen video")
+
+  val disabledCombinedVideo by parser.flagging("--disable-combined-video",
+          help = "Disable combining multiple videos into one")
+
   val adbTimeout by parser.storing("--adb-timeout",
       help = "Maximum execution time per test. Parsed by java.time.Duration.",
       transform = Duration::parse).default(null)

--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
@@ -23,18 +23,23 @@ public final class DeviceTestResult {
   private final StackTrace exception;
   private final long duration;
   private final List<File> screenshots;
+  private final List<File> videos;
   private final List<File> files;
   private final File animatedGif;
+  private final File combinedVideo;
   private final List<LogCatMessage> log;
 
   private DeviceTestResult(Status status, StackTrace exception, long duration,
-      List<File> screenshots, File animatedGif, List<LogCatMessage> log, List<File> files) {
+      List<File> screenshots, List<File> videos, File animatedGif,
+      File combinedVideo, List<LogCatMessage> log, List<File> files) {
     this.status = status;
     this.exception = exception;
     this.duration = duration;
     this.screenshots = unmodifiableList(new ArrayList<>(screenshots));
+    this.videos = unmodifiableList(new ArrayList<>(videos));
     this.files = unmodifiableList(new ArrayList<>(files));
     this.animatedGif = animatedGif;
+    this.combinedVideo = combinedVideo;
     this.log = unmodifiableList(new ArrayList<>(log));
   }
 
@@ -58,9 +63,19 @@ public final class DeviceTestResult {
     return screenshots;
   }
 
+  /** Videos taken during test. */
+  public List<File> getVideos() {
+    return videos;
+  }
+
   /** Animated GIF of screenshots. */
   public File getAnimatedGif() {
     return animatedGif;
+  }
+
+  /** Combined video of all videos. **/
+  public File getCombinedVideo() {
+    return combinedVideo;
   }
 
   /** Arbitrary files saved from the test */
@@ -171,7 +186,7 @@ public final class DeviceTestResult {
         log = Collections.emptyList();
       }
       return new DeviceTestResult(status, exception, duration,
-              screenshots, animatedGif, log, files);
+              screenshots, videos, animatedGif, combinedVideo, log, files);
     }
   }
 }

--- a/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/DeviceTestResult.java
@@ -75,11 +75,13 @@ public final class DeviceTestResult {
   public static class Builder {
     private final List<File> screenshots = new ArrayList<>();
     private final List<File> files = new ArrayList<>();
+    private final List<File> videos = new ArrayList<>();
     private Status status = Status.PASS;
     private StackTrace exception;
     private long start;
     private long duration = -1;
     private File animatedGif;
+    private File combinedVideo;
     private List<LogCatMessage> log;
 
     public Builder markTestAsFailed(String message) {
@@ -138,6 +140,12 @@ public final class DeviceTestResult {
       return this;
     }
 
+    public Builder addVideo(File video) {
+      checkNotNull(video);
+      videos.add(video);
+      return this;
+    }
+
     public Builder addFile(File file) {
       checkNotNull(file);
       files.add(file);
@@ -148,6 +156,13 @@ public final class DeviceTestResult {
       checkNotNull(animatedGif);
       checkArgument(this.animatedGif == null, "Animated GIF already set.");
       this.animatedGif = animatedGif;
+      return this;
+    }
+
+    public Builder setCombinedVideo(File combinedVideo) {
+      checkNotNull(combinedVideo);
+      checkArgument(this.combinedVideo == null, "Combined video already set.");
+      this.combinedVideo = combinedVideo;
       return this;
     }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorder.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorder.java
@@ -1,7 +1,6 @@
 package com.squareup.spoon;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -26,90 +25,89 @@ import com.android.ddmlib.IShellOutputReceiver;
  */
 final class ScreenRecorder implements Closeable {
 
-    static ScreenRecorder open(
-            IDevice device, File deviceOutputDirectory, ExecutorService executorService, boolean debug) {
-        return new ScreenRecorder(
-                device,
-                deviceOutputDirectory,
-                DEFAULT_RECORD_BUFFER_DURATION_SECONDS,
-                DEFAULT_RECORD_BITRATE_MBPS,
-                executorService,
-                debug);
-    }
+  static ScreenRecorder open(
+      IDevice device, String deviceOutputDirectoryPath, ExecutorService executorService, boolean debug) {
+    return new ScreenRecorder(
+        device,
+        deviceOutputDirectoryPath,
+        DEFAULT_RECORD_BUFFER_DURATION_SECONDS,
+        DEFAULT_RECORD_BITRATE_MBPS,
+        executorService,
+        debug);
+  }
 
-    private static final String COMMAND_SCREEN_RECORD = "screenrecord";
-    private static final String PREFIX_ARGUMENT = "--";
-    private static final String ARGUMENT_TIME_LIMIT = PREFIX_ARGUMENT + "time-limit";
-    private static final String ARGUMENT_VERBOSE = PREFIX_ARGUMENT + "verbose";
-    private static final String ARGUMENT_BITRATE = PREFIX_ARGUMENT + "bit-rate";
-    private static final long DEFAULT_RECORD_BUFFER_DURATION_SECONDS = 5L;
-    private static final int DEFAULT_RECORD_BITRATE_MBPS = 3000000;
+  private static final String COMMAND_SCREEN_RECORD = "screenrecord";
+  private static final String PREFIX_ARGUMENT = "--";
+  private static final String ARGUMENT_TIME_LIMIT = PREFIX_ARGUMENT + "time-limit";
+  private static final String ARGUMENT_VERBOSE = PREFIX_ARGUMENT + "verbose";
+  private static final String ARGUMENT_BITRATE = PREFIX_ARGUMENT + "bit-rate";
+  private static final long DEFAULT_RECORD_BUFFER_DURATION_SECONDS = 180L;
+  private static final int DEFAULT_RECORD_BITRATE_MBPS = 3000000;
 
-    private final Future<?> mRecordingTask;
-    private final AtomicBoolean mDone = new AtomicBoolean();
+  private final Future<?> mRecordingTask;
+  private final AtomicBoolean mDone = new AtomicBoolean();
 
-    private ScreenRecorder(
-            final IDevice device,
-            File deviceOutputDirectory,
-            final long recordBufferDurationSeconds,
-            final int recordBitRateMbps,
-            ExecutorService executorService,
-            boolean debug) {
-        mRecordingTask = executorService.submit(() -> {
-            long recordingIndex = 0;
-            while (!mDone.get()) {
-                try {
-                    File recordingFile = new File(deviceOutputDirectory, "recording_" + recordingIndex + ".mp4");
-                    String command = Joiner.on(' ').join(new Object[] {
-                            COMMAND_SCREEN_RECORD,
-                            ARGUMENT_TIME_LIMIT, recordBufferDurationSeconds,
-                            ARGUMENT_BITRATE, recordBitRateMbps,
-                            ARGUMENT_VERBOSE,
-                            recordingFile.getAbsolutePath()
-                    });
-                    logDebug(debug, "Executing command: [%s]", command);
-                    StringBuilder outputBuffer = new StringBuilder();
-                    CountDownLatch completionLatch = new CountDownLatch(1);
-                    device.executeShellCommand(command, new IShellOutputReceiver() {
-                        @Override
-                        public void addOutput(byte[] data, int offset, int length) {
-                            if (!isCancelled()) {
-                                outputBuffer.append(new String(data, offset, length, Charsets.UTF_8));
-                            }
-                        }
-
-                        @Override
-                        public void flush() {
-                            completionLatch.countDown();
-                        }
-
-                        @Override
-                        public boolean isCancelled() {
-                            return mDone.get();
-                        }
-                    });
-                    if (!mDone.get()) {
-                        completionLatch.await(recordBufferDurationSeconds * 2, TimeUnit.SECONDS);
-                    }
-                    logDebug(debug, "Finished command execution with result: [%S]", outputBuffer.toString());
-                } catch (Throwable e) {
-                   logError("Failed to record: %s", e);
-                }
-                recordingIndex++;
+  private ScreenRecorder(
+      IDevice device,
+      String deviceOutputDirectoryPath,
+      long recordBufferDurationSeconds,
+      int recordBitRateMbps,
+      ExecutorService executorService,
+      boolean debug) {
+    mRecordingTask = executorService.submit(() -> {
+      int recordingIndex = 0;
+      while (!mDone.get()) {
+        try {
+          String command = Joiner.on(' ').join(new Object[]{
+              COMMAND_SCREEN_RECORD,
+              ARGUMENT_TIME_LIMIT, recordBufferDurationSeconds,
+              ARGUMENT_BITRATE, recordBitRateMbps,
+              ARGUMENT_VERBOSE,
+              deviceOutputDirectoryPath + '/' + COMMAND_SCREEN_RECORD + '_' + recordingIndex + ".mp4"
+          });
+          logDebug(debug, "Executing command: [%s]", command);
+          StringBuilder outputBuffer = new StringBuilder();
+          CountDownLatch completionLatch = new CountDownLatch(1);
+          device.executeShellCommand(command, new IShellOutputReceiver() {
+            @Override
+            public void addOutput(byte[] data, int offset, int length) {
+              if (!isCancelled()) {
+                outputBuffer.append(new String(data, offset, length, Charsets.UTF_8));
+              }
             }
-        });
-    }
 
-    @Override
-    public void close() throws IOException {
-        if (mDone.compareAndSet(false, true)) {
-            try {
-                mRecordingTask.get();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (ExecutionException e) {
-                throw new IOException(e);
+            @Override
+            public void flush() {
+              completionLatch.countDown();
             }
+
+            @Override
+            public boolean isCancelled() {
+              return mDone.get();
+            }
+          });
+          if (!mDone.get()) {
+            completionLatch.await(recordBufferDurationSeconds * 2, TimeUnit.SECONDS);
+          }
+          logDebug(debug, "Finished command execution with result: [%S]", outputBuffer.toString());
+        } catch (Throwable e) {
+          logError("Failed to record: %s", e);
         }
+        recordingIndex++;
+      }
+    });
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (mDone.compareAndSet(false, true)) {
+      try {
+        mRecordingTask.get();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException e) {
+        throw new IOException(e);
+      }
     }
+  }
 }

--- a/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorder.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorder.java
@@ -1,0 +1,115 @@
+package com.squareup.spoon;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
+
+import static com.squareup.spoon.SpoonLogger.logDebug;
+import static com.squareup.spoon.SpoonLogger.logError;
+
+import com.android.ddmlib.IDevice;
+import com.android.ddmlib.IShellOutputReceiver;
+
+/**
+ * For more information on Android's {@code screenrecord} executable see:
+ * https://developer.android.com/studio/command-line/adb.html#screenrecord,
+ * https://android.googlesource.com/platform/frameworks/av/+/android-cts-4.4_r1/cmds/screenrecord/screenrecord.cpp
+ */
+final class ScreenRecorder implements Closeable {
+
+    static ScreenRecorder open(
+            IDevice device, File deviceOutputDirectory, ExecutorService executorService, boolean debug) {
+        return new ScreenRecorder(
+                device,
+                deviceOutputDirectory,
+                DEFAULT_RECORD_BUFFER_DURATION_SECONDS,
+                DEFAULT_RECORD_BITRATE_MBPS,
+                executorService,
+                debug);
+    }
+
+    private static final String COMMAND_SCREEN_RECORD = "screenrecord";
+    private static final String PREFIX_ARGUMENT = "--";
+    private static final String ARGUMENT_TIME_LIMIT = PREFIX_ARGUMENT + "time-limit";
+    private static final String ARGUMENT_VERBOSE = PREFIX_ARGUMENT + "verbose";
+    private static final String ARGUMENT_BITRATE = PREFIX_ARGUMENT + "bit-rate";
+    private static final long DEFAULT_RECORD_BUFFER_DURATION_SECONDS = 5L;
+    private static final int DEFAULT_RECORD_BITRATE_MBPS = 3000000;
+
+    private final Future<?> mRecordingTask;
+    private final AtomicBoolean mDone = new AtomicBoolean();
+
+    private ScreenRecorder(
+            final IDevice device,
+            File deviceOutputDirectory,
+            final long recordBufferDurationSeconds,
+            final int recordBitRateMbps,
+            ExecutorService executorService,
+            boolean debug) {
+        mRecordingTask = executorService.submit(() -> {
+            long recordingIndex = 0;
+            while (!mDone.get()) {
+                try {
+                    File recordingFile = new File(deviceOutputDirectory, "recording_" + recordingIndex + ".mp4");
+                    String command = Joiner.on(' ').join(new Object[] {
+                            COMMAND_SCREEN_RECORD,
+                            ARGUMENT_TIME_LIMIT, recordBufferDurationSeconds,
+                            ARGUMENT_BITRATE, recordBitRateMbps,
+                            ARGUMENT_VERBOSE,
+                            recordingFile.getAbsolutePath()
+                    });
+                    logDebug(debug, "Executing command: [%s]", command);
+                    StringBuilder outputBuffer = new StringBuilder();
+                    CountDownLatch completionLatch = new CountDownLatch(1);
+                    device.executeShellCommand(command, new IShellOutputReceiver() {
+                        @Override
+                        public void addOutput(byte[] data, int offset, int length) {
+                            if (!isCancelled()) {
+                                outputBuffer.append(new String(data, offset, length, Charsets.UTF_8));
+                            }
+                        }
+
+                        @Override
+                        public void flush() {
+                            completionLatch.countDown();
+                        }
+
+                        @Override
+                        public boolean isCancelled() {
+                            return mDone.get();
+                        }
+                    });
+                    if (!mDone.get()) {
+                        completionLatch.await(recordBufferDurationSeconds * 2, TimeUnit.SECONDS);
+                    }
+                    logDebug(debug, "Finished command execution with result: [%S]", outputBuffer.toString());
+                } catch (Throwable e) {
+                   logError("Failed to record: %s", e);
+                }
+                recordingIndex++;
+            }
+        });
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (mDone.compareAndSet(false, true)) {
+            try {
+                mRecordingTask.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (ExecutionException e) {
+                throw new IOException(e);
+            }
+        }
+    }
+}

--- a/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorder.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorder.java
@@ -20,13 +20,13 @@ import com.android.ddmlib.IShellOutputReceiver;
 
 /**
  * For more information on Android's {@code screenrecord} executable see:
- * https://developer.android.com/studio/command-line/adb.html#screenrecord,
- * https://android.googlesource.com/platform/frameworks/av/+/android-cts-4.4_r1/cmds/screenrecord/screenrecord.cpp
+ * https://developer.android.com/studio/command-line/adb.html#screenrecord, https://goo.gl/6deC5j.
  */
 final class ScreenRecorder implements Closeable {
 
   static ScreenRecorder open(
-      IDevice device, String deviceOutputDirectoryPath, ExecutorService executorService, boolean debug) {
+      IDevice device, String deviceOutputDirectoryPath,
+      ExecutorService executorService, boolean debug) {
     return new ScreenRecorder(
         device,
         deviceOutputDirectoryPath,
@@ -63,7 +63,8 @@ final class ScreenRecorder implements Closeable {
               ARGUMENT_TIME_LIMIT, recordBufferDurationSeconds,
               ARGUMENT_BITRATE, recordBitRateMbps,
               ARGUMENT_VERBOSE,
-              deviceOutputDirectoryPath + '/' + COMMAND_SCREEN_RECORD + '_' + recordingIndex + ".mp4"
+              deviceOutputDirectoryPath + '/'
+                  + COMMAND_SCREEN_RECORD + '_' + recordingIndex + ".mp4"
           });
           logDebug(debug, "Executing command: [%s]", command);
           StringBuilder outputBuffer = new StringBuilder();

--- a/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
@@ -40,7 +40,8 @@ final class ScreenRecorderTestRunListener implements ITestRunListener {
   public void testStarted(TestIdentifier test) {
     String deviceDirectory = createDeviceDirectoryFor(test);
     if (deviceDirectory != null) {
-      screenRecorders.put(test, ScreenRecorder.open(device, deviceDirectory, executorService, debug));
+      screenRecorders.put(
+          test, ScreenRecorder.open(device, deviceDirectory, executorService, debug));
     }
   }
 
@@ -75,8 +76,8 @@ final class ScreenRecorderTestRunListener implements ITestRunListener {
 
   private String createDeviceDirectoryFor(TestIdentifier testIdentifier) {
     try {
-      String deviceTestDirectory = deviceDirectoryPath + '/' +
-          testIdentifier.getClassName() + '/' + testIdentifier.getTestName();
+      String deviceTestDirectory = deviceDirectoryPath + '/'
+          + testIdentifier.getClassName() + '/' + testIdentifier.getTestName();
       CollectingOutputReceiver outputReceiver = new CollectingOutputReceiver();
       device.executeShellCommand("mkdir -p " + deviceTestDirectory, outputReceiver);
       return deviceTestDirectory;

--- a/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
@@ -1,10 +1,10 @@
 package com.squareup.spoon;
 
-import java.io.File;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 
+import static com.squareup.spoon.SpoonLogger.logError;
 import static org.apache.commons.io.IOUtils.closeQuietly;
 
 import com.android.ddmlib.CollectingOutputReceiver;
@@ -14,74 +14,75 @@ import com.android.ddmlib.testrunner.TestIdentifier;
 
 final class ScreenRecorderTestRunListener implements ITestRunListener {
 
-    private final IDevice device;
-    private final String deviceFilesDir;
-    private final ExecutorService executorService;
-    private final boolean debug;
+  private final IDevice device;
+  private final String deviceDirectoryPath;
+  private final ExecutorService executorService;
+  private final boolean debug;
 
-    private final Map<TestIdentifier, ScreenRecorder> screenRecorders = new ConcurrentHashMap<>();
+  private final Map<TestIdentifier, ScreenRecorder> screenRecorders = new ConcurrentHashMap<>();
 
-    ScreenRecorderTestRunListener(
-            IDevice device,
-            String deviceFilesDir,
-            ExecutorService executorService,
-            boolean debug) {
-        this.device = device;
-        this.deviceFilesDir = deviceFilesDir;
-        this.executorService = executorService;
-        this.debug = debug;
+  ScreenRecorderTestRunListener(
+      IDevice device,
+      String deviceDirectoryPath,
+      ExecutorService executorService,
+      boolean debug) {
+    this.device = device;
+    this.deviceDirectoryPath = deviceDirectoryPath;
+    this.executorService = executorService;
+    this.debug = debug;
+  }
+
+  @Override
+  public void testRunStarted(String runName, int testCount) {
+  }
+
+  @Override
+  public void testStarted(TestIdentifier test) {
+    String deviceDirectory = createDeviceDirectoryFor(test);
+    if (deviceDirectory != null) {
+      screenRecorders.put(test, ScreenRecorder.open(device, deviceDirectory, executorService, debug));
     }
+  }
 
-    @Override
-    public void testRunStarted(String runName, int testCount) {
-    }
+  @Override
+  public void testFailed(TestIdentifier test, String trace) {
+  }
 
-    @Override
-    public void testStarted(TestIdentifier test) {
-        screenRecorders.put(test, ScreenRecorder.open(device, createDeviceDirectoryFor(test), executorService, debug));
-    }
+  @Override
+  public void testAssumptionFailure(TestIdentifier test, String trace) {
+  }
 
-    @Override
-    public void testFailed(TestIdentifier test, String trace) {
-    }
+  @Override
+  public void testIgnored(TestIdentifier test) {
+  }
 
-    @Override
-    public void testAssumptionFailure(TestIdentifier test, String trace) {
-    }
+  @Override
+  public void testEnded(TestIdentifier test, Map<String, String> testMetrics) {
+    closeQuietly(screenRecorders.remove(test));
+  }
 
-    @Override
-    public void testIgnored(TestIdentifier test) {
-    }
+  @Override
+  public void testRunFailed(String errorMessage) {
+  }
 
-    @Override
-    public void testEnded(TestIdentifier test, Map<String, String> testMetrics) {
-        closeQuietly(screenRecorders.remove(test));
-    }
+  @Override
+  public void testRunStopped(long elapsedTime) {
+  }
 
-    @Override
-    public void testRunFailed(String errorMessage) {
-    }
+  @Override
+  public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
+  }
 
-    @Override
-    public void testRunStopped(long elapsedTime) {
+  private String createDeviceDirectoryFor(TestIdentifier testIdentifier) {
+    try {
+      String deviceTestDirectory = deviceDirectoryPath + '/' +
+          testIdentifier.getClassName() + '/' + testIdentifier.getTestName();
+      CollectingOutputReceiver outputReceiver = new CollectingOutputReceiver();
+      device.executeShellCommand("mkdir -p " + deviceTestDirectory, outputReceiver);
+      return deviceTestDirectory;
+    } catch (Exception e) {
+      logError("Failed to create device directory for test [%s] due to [%s]", testIdentifier, e);
+      return null;
     }
-
-    @Override
-    public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
-    }
-
-    private File createDeviceDirectoryFor(TestIdentifier testIdentifier) {
-        try {
-            CollectingOutputReceiver outputReceiver = new CollectingOutputReceiver();
-            device.executeShellCommand("echo $EXTERNAL_STORAGE", outputReceiver);
-            File deviceTestsDirectory = new File(outputReceiver.getOutput().trim(), deviceFilesDir);
-            File deviceTestDirectory = new File(
-                    deviceTestsDirectory, testIdentifier.getClassName() + "/" + testIdentifier.getTestName());
-            outputReceiver = new CollectingOutputReceiver();
-            device.executeShellCommand("mkdir -p " + deviceTestDirectory.getAbsolutePath(), outputReceiver);
-            return  deviceTestDirectory;
-        } catch (Exception e) {
-            throw new RuntimeException("Could not get external storage path", e);
-        }
-    }
+  }
 }

--- a/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
@@ -1,8 +1,11 @@
 package com.squareup.spoon;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static com.squareup.spoon.SpoonLogger.logError;
 import static org.apache.commons.io.IOUtils.closeQuietly;
@@ -12,7 +15,7 @@ import com.android.ddmlib.IDevice;
 import com.android.ddmlib.testrunner.ITestRunListener;
 import com.android.ddmlib.testrunner.TestIdentifier;
 
-final class ScreenRecorderTestRunListener implements ITestRunListener {
+final class ScreenRecorderTestRunListener implements ITestRunListener, Closeable {
 
   private final IDevice device;
   private final String deviceDirectoryPath;
@@ -20,6 +23,13 @@ final class ScreenRecorderTestRunListener implements ITestRunListener {
   private final boolean debug;
 
   private final Map<TestIdentifier, ScreenRecorder> screenRecorders = new ConcurrentHashMap<>();
+
+  ScreenRecorderTestRunListener(
+      IDevice device,
+      String deviceDirectoryPath,
+      boolean debug) {
+    this(device, deviceDirectoryPath,  Executors.newSingleThreadExecutor(), debug);
+  }
 
   ScreenRecorderTestRunListener(
       IDevice device,
@@ -72,6 +82,11 @@ final class ScreenRecorderTestRunListener implements ITestRunListener {
 
   @Override
   public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
+  }
+
+  @Override
+  public void close() throws IOException {
+    executorService.shutdown();
   }
 
   private String createDeviceDirectoryFor(TestIdentifier testIdentifier) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/ScreenRecorderTestRunListener.java
@@ -1,0 +1,87 @@
+package com.squareup.spoon;
+
+import java.io.File;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+
+import static org.apache.commons.io.IOUtils.closeQuietly;
+
+import com.android.ddmlib.CollectingOutputReceiver;
+import com.android.ddmlib.IDevice;
+import com.android.ddmlib.testrunner.ITestRunListener;
+import com.android.ddmlib.testrunner.TestIdentifier;
+
+final class ScreenRecorderTestRunListener implements ITestRunListener {
+
+    private final IDevice device;
+    private final String deviceFilesDir;
+    private final ExecutorService executorService;
+    private final boolean debug;
+
+    private final Map<TestIdentifier, ScreenRecorder> screenRecorders = new ConcurrentHashMap<>();
+
+    ScreenRecorderTestRunListener(
+            IDevice device,
+            String deviceFilesDir,
+            ExecutorService executorService,
+            boolean debug) {
+        this.device = device;
+        this.deviceFilesDir = deviceFilesDir;
+        this.executorService = executorService;
+        this.debug = debug;
+    }
+
+    @Override
+    public void testRunStarted(String runName, int testCount) {
+    }
+
+    @Override
+    public void testStarted(TestIdentifier test) {
+        screenRecorders.put(test, ScreenRecorder.open(device, createDeviceDirectoryFor(test), executorService, debug));
+    }
+
+    @Override
+    public void testFailed(TestIdentifier test, String trace) {
+    }
+
+    @Override
+    public void testAssumptionFailure(TestIdentifier test, String trace) {
+    }
+
+    @Override
+    public void testIgnored(TestIdentifier test) {
+    }
+
+    @Override
+    public void testEnded(TestIdentifier test, Map<String, String> testMetrics) {
+        closeQuietly(screenRecorders.remove(test));
+    }
+
+    @Override
+    public void testRunFailed(String errorMessage) {
+    }
+
+    @Override
+    public void testRunStopped(long elapsedTime) {
+    }
+
+    @Override
+    public void testRunEnded(long elapsedTime, Map<String, String> runMetrics) {
+    }
+
+    private File createDeviceDirectoryFor(TestIdentifier testIdentifier) {
+        try {
+            CollectingOutputReceiver outputReceiver = new CollectingOutputReceiver();
+            device.executeShellCommand("echo $EXTERNAL_STORAGE", outputReceiver);
+            File deviceTestsDirectory = new File(outputReceiver.getOutput().trim(), deviceFilesDir);
+            File deviceTestDirectory = new File(
+                    deviceTestsDirectory, testIdentifier.getClassName() + "/" + testIdentifier.getTestName());
+            outputReceiver = new CollectingOutputReceiver();
+            device.executeShellCommand("mkdir -p " + deviceTestDirectory.getAbsolutePath(), outputReceiver);
+            return  deviceTestDirectory;
+        } catch (Exception e) {
+            throw new RuntimeException("Could not get external storage path", e);
+        }
+    }
+}

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -490,7 +490,7 @@ public final class SpoonDeviceRunner {
 
   private void handleVideos(DeviceResult.Builder result, File videosDir) throws IOException {
     logDebug(debug, "Moving videos to the video folder on [%s]", serial);
-    // Move all children of the screenshot directory into the image folder.
+    // Move all children of the videos directory into the video folder.
     File[] classNameDirs = videosDir.listFiles();
     if (classNameDirs != null) {
       Multimap<DeviceTest, File> testVideos = ArrayListMultimap.create();

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -235,7 +235,12 @@ public final class SpoonDeviceRunner {
     listeners.add(new SpoonTestRunListener(result, debug));
     listeners.add(new XmlTestRunListener(junitReport));
     ExecutorService executorService = Executors.newSingleThreadExecutor();
-    listeners.add(new ScreenRecorderTestRunListener(device, DEVICE_VIDEO_DIR, executorService, debug));
+    try {
+      listeners.add(new ScreenRecorderTestRunListener(
+              device, getExternalStoragePath(device, DEVICE_VIDEO_DIR), executorService, debug));
+    } catch (Exception e) {
+      logError("Failed to setup a screen recorder: [%s]", e);
+    }
     if (testRunListeners != null) {
       listeners.addAll(testRunListeners);
     }
@@ -501,14 +506,15 @@ public final class SpoonDeviceRunner {
         }
       }
 
-      logDebug(debug, "Generating combined video for [%s] [%s]", serial, testVideos);
+      logDebug(debug, "Generating combined video for [%s]", serial);
       // Don't generate animations if the switch is present
       if (true) {
         // Make combined videos for all the tests which have videos.
         for (DeviceTest deviceTest : testVideos.keySet()) {
           List<File> videos = new ArrayList<>(testVideos.get(deviceTest));
           if (videos.size() == 1) {
-            continue; // Do not make a combined video if there is only one video.
+            result.getMethodResultBuilder(deviceTest).setCombinedVideo(videos.get(0));
+            continue;
           }
           File video = FileUtils.getFile(videoDir, deviceTest.getClassName(),
                   deviceTest.getMethodName() + ".mp4");

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -53,7 +53,8 @@ public final class SpoonDeviceRunner {
   private static final String DEVICE_SCREENSHOT_DIR = "app_" + SPOON_SCREENSHOTS;
   private static final String DEVICE_VIDEO_DIR = "app_" + SPOON_VIDEOS;
   private static final String DEVICE_FILE_DIR = "app_" + SPOON_FILES;
-  private static final String[] DEVICE_DIRS = {DEVICE_SCREENSHOT_DIR, DEVICE_VIDEO_DIR, DEVICE_FILE_DIR};
+  private static final String[] DEVICE_DIRS =
+      {DEVICE_SCREENSHOT_DIR, DEVICE_VIDEO_DIR, DEVICE_FILE_DIR};
   static final String TEMP_DIR = "work";
   static final String JUNIT_DIR = "junit-reports";
   static final String IMAGE_DIR = "image";

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonRunner.java
@@ -49,6 +49,8 @@ public final class SpoonRunner {
   private final File output;
   private final boolean debug;
   private final boolean noAnimations;
+  private final boolean recordVideo;
+  private final boolean noCombinedVideo;
   private final Duration adbTimeout;
   private final ImmutableMap<String, String> instrumentationArgs;
   private final String className;
@@ -66,7 +68,8 @@ public final class SpoonRunner {
   private final boolean singleInstrumentationCall;
 
   private SpoonRunner(String title, File androidSdk, File testApk, List<File> otherApks,
-      File output, boolean debug, boolean noAnimations, Duration adbTimeout, Set<String> serials,
+      File output, boolean debug, boolean noAnimations, boolean recordVideo,
+      boolean noCombinedVideo, Duration adbTimeout, Set<String> serials,
       Set<String> skipDevices, boolean shard, Map<String, String> instrumentationArgs,
       String className, String methodName, IRemoteAndroidTestRunner.TestSize testSize,
       boolean allowNoDevices, List<ITestRunListener> testRunListeners, boolean sequential,
@@ -79,6 +82,8 @@ public final class SpoonRunner {
     this.output = output;
     this.debug = debug;
     this.noAnimations = noAnimations;
+    this.recordVideo = recordVideo;
+    this.noCombinedVideo = noCombinedVideo;
     this.adbTimeout = adbTimeout;
     this.instrumentationArgs = ImmutableMap.copyOf(instrumentationArgs != null
         ? instrumentationArgs : emptyMap());
@@ -294,8 +299,9 @@ public final class SpoonRunner {
   private SpoonDeviceRunner getTestRunner(String serial, int shardIndex, int numShards,
       SpoonInstrumentationInfo testInfo) {
     return new SpoonDeviceRunner(testApk, otherApks, output, serial, shardIndex, numShards, debug,
-        noAnimations, adbTimeout, testInfo, instrumentationArgs, className, methodName, testSize,
-        testRunListeners, codeCoverage, grantAll, singleInstrumentationCall);
+        noAnimations, recordVideo, noCombinedVideo, adbTimeout, testInfo, instrumentationArgs,
+        className, methodName, testSize, testRunListeners, codeCoverage, grantAll,
+        singleInstrumentationCall);
   }
 
   /** Build a test suite for the specified devices and configuration. */
@@ -312,6 +318,8 @@ public final class SpoonRunner {
     private String className;
     private String methodName;
     private boolean noAnimations;
+    private boolean recordVideo;
+    private boolean noCombinedVideo;
     private IRemoteAndroidTestRunner.TestSize testSize;
     private Duration adbTimeout = DEFAULT_ADB_TIMEOUT;
     private boolean allowNoDevices;
@@ -371,6 +379,18 @@ public final class SpoonRunner {
     /** Whether or not animations are enabled. */
     public Builder setNoAnimations(boolean noAnimations) {
       this.noAnimations = noAnimations;
+      return this;
+    }
+
+    /** Whether or not device screen video should be taken. **/
+    public Builder setRecordVideo(boolean recordVideo) {
+      this.recordVideo = recordVideo;
+      return this;
+    }
+
+    /** Whether or not multiple device screen videos should be combined into one. **/
+    public Builder setNoCombinedVideo(boolean noCombinedVideo) {
+      this.noCombinedVideo = noCombinedVideo;
       return this;
     }
 
@@ -475,9 +495,9 @@ public final class SpoonRunner {
       }
 
       return new SpoonRunner(title, androidSdk, testApk, otherApks, output, debug, noAnimations,
-          adbTimeout, serials, skipDevices, shard, instrumentationArgs, className, methodName,
-          testSize, allowNoDevices, testRunListeners, sequential, initScript, grantAll,
-          terminateAdb, codeCoverage, singleInstrumentationCall);
+          recordVideo, noCombinedVideo, adbTimeout, serials, skipDevices, shard,
+          instrumentationArgs, className, methodName, testSize, allowNoDevices, testRunListeners,
+          sequential, initScript, grantAll, terminateAdb, codeCoverage, singleInstrumentationCall);
     }
   }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
@@ -36,6 +36,7 @@ import org.apache.commons.io.IOUtils;
 
 import static com.android.ddmlib.FileListingService.FileEntry;
 import static com.android.ddmlib.FileListingService.TYPE_DIRECTORY;
+import static org.apache.commons.io.IOUtils.closeQuietly;
 
 /** Utilities for executing instrumentation tests on devices. */
 public final class SpoonUtils {
@@ -179,7 +180,7 @@ public final class SpoonUtils {
       Container out = new DefaultMp4Builder().build(movie);
       out.writeContainer(fileOutputStream.getChannel());
     } finally {
-      IOUtils.closeQuietly(fileOutputStream);
+      closeQuietly(fileOutputStream);
     }
   }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
@@ -3,26 +3,36 @@ package com.squareup.spoon;
 import com.android.ddmlib.AndroidDebugBridge;
 import com.android.ddmlib.DdmPreferences;
 import com.android.ddmlib.IDevice;
+import com.coremedia.iso.boxes.Container;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import com.googlecode.mp4parser.authoring.Movie;
+import com.googlecode.mp4parser.authoring.Track;
+import com.googlecode.mp4parser.authoring.builder.DefaultMp4Builder;
+import com.googlecode.mp4parser.authoring.container.mp4.MovieCreator;
+import com.googlecode.mp4parser.authoring.tracks.AppendTrack;
 import com.madgag.gif.fmsware.AnimatedGifEncoder;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 import static com.android.ddmlib.FileListingService.FileEntry;
 import static com.android.ddmlib.FileListingService.TYPE_DIRECTORY;
@@ -146,6 +156,31 @@ public final class SpoonUtils {
     }
 
     encoder.finish();
+  }
+
+  static void createCombinedVideo(List<File> testVideos, File video) throws IOException {
+    FileOutputStream fileOutputStream = new FileOutputStream(video);
+    try {
+      List<Movie> movies = new ArrayList<>();
+      for (File recording : testVideos) {
+          movies.add(MovieCreator.build(recording.getAbsolutePath()));
+      }
+      List<Track> videoTracks = new LinkedList<>();
+      for (Movie movie : movies) {
+          for (Track track : movie.getTracks()) {
+              if (!track.getHandler().startsWith("vide") || track.getSyncSamples() == null) {
+                  continue;
+              }
+              videoTracks.add(track);
+          }
+      }
+      Movie movie = new Movie();
+      movie.addTrack(new AppendTrack(videoTracks.toArray(new Track[videoTracks.size()])));
+      Container out = new DefaultMp4Builder().build(movie);
+      out.writeContainer(fileOutputStream.getChannel());
+    } finally {
+      IOUtils.closeQuietly(fileOutputStream);
+    }
   }
 
   private static void waitForAdb(AndroidDebugBridge adb, Duration timeOut) {

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonUtils.java
@@ -32,7 +32,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import javax.imageio.ImageIO;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 
 import static com.android.ddmlib.FileListingService.FileEntry;
 import static com.android.ddmlib.FileListingService.TYPE_DIRECTORY;

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlDevice.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlDevice.java
@@ -84,14 +84,19 @@ final class HtmlDevice {
           .stream()
           .map(screenshot -> HtmlUtils.getScreenshot(screenshot, output))
           .collect(toList());
+      String animatedGif = HtmlUtils.createRelativeUri(result.getAnimatedGif(), output);
+      List<HtmlUtils.Video> videos = result.getVideos()
+          .stream()
+          .map(video -> HtmlUtils.getVideo(video, output))
+          .collect(toList());
+      String combinedVideo = HtmlUtils.createRelativeUri(result.getCombinedVideo(), output);
       List<HtmlUtils.SavedFile> files = result.getFiles()
           .stream()
           .map(file -> HtmlUtils.getFile(file, output))
           .collect(toList());
-      String animatedGif = HtmlUtils.createRelativeUri(result.getAnimatedGif(), output);
       HtmlUtils.ExceptionInfo exception = HtmlUtils.processStackTrace(result.getException());
       return new TestResult(serial, className, methodName, classSimpleName, methodName,
-          testId, status, screenshots, animatedGif, exception, files);
+          testId, status, screenshots, animatedGif, videos, combinedVideo, exception, files);
     }
 
     public final String serial;
@@ -106,11 +111,15 @@ final class HtmlDevice {
     public final List<HtmlUtils.SavedFile> files;
     public final boolean hasFiles;
     public final String animatedGif;
+    public final List<HtmlUtils.Video> videos;
+    public final boolean hasVideos;
+    public final String combinedVideo;
     public final HtmlUtils.ExceptionInfo exception;
 
     TestResult(String serial, String className, String methodName, String classSimpleName,
         String prettyMethodName, String testId, String status,
         List<HtmlUtils.Screenshot> screenshots, String animatedGif,
+        List<HtmlUtils.Video> videos, String combinedVideo,
         HtmlUtils.ExceptionInfo exception, List<HtmlUtils.SavedFile> files) {
       this.serial = serial;
       this.className = className;
@@ -122,6 +131,9 @@ final class HtmlDevice {
       this.hasScreenshots = !screenshots.isEmpty();
       this.screenshots = screenshots;
       this.animatedGif = animatedGif;
+      this.hasVideos = !videos.isEmpty();
+      this.videos = videos;
+      this.combinedVideo = combinedVideo;
       this.exception = exception;
       this.files = files;
       this.hasFiles = !files.isEmpty();

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlTest.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlTest.java
@@ -83,9 +83,15 @@ final class HtmlTest {
           .map(screenshot -> HtmlUtils.getScreenshot(screenshot, output))
           .collect(toList());
       String animatedGif = HtmlUtils.createRelativeUri(result.getAnimatedGif(), output);
+      List<HtmlUtils.Video> videos = result.getScreenshots()
+          .stream()
+          .map(screenshot -> HtmlUtils.getVideo(screenshot, output))
+          .collect(toList());
+      String combinedVideo = HtmlUtils.createRelativeUri(result.getCombinedVideo(), output);
       HtmlUtils.ExceptionInfo exception = HtmlUtils.processStackTrace(result.getException());
 
-      return new TestResult(name, serial, status, screenshots, animatedGif, exception);
+      return new TestResult(
+          name, serial, status, screenshots, animatedGif, videos, combinedVideo, exception);
     }
 
     public final String name;
@@ -94,16 +100,23 @@ final class HtmlTest {
     public final boolean hasScreenshots;
     public final List<HtmlUtils.Screenshot> screenshots;
     public final String animatedGif;
+    public final boolean hasVideos;
+    public final List<HtmlUtils.Video> videos;
+    public final String combinedVideo;
     public final HtmlUtils.ExceptionInfo exception;
 
     TestResult(String name, String serial, String status, List<HtmlUtils.Screenshot> screenshots,
-        String animatedGif, HtmlUtils.ExceptionInfo exception) {
+        String animatedGif, List<HtmlUtils.Video> videos, String combinedVideo,
+        HtmlUtils.ExceptionInfo exception) {
       this.name = name;
       this.serial = serial;
       this.status = status;
       this.hasScreenshots = !screenshots.isEmpty();
       this.screenshots = screenshots;
       this.animatedGif = animatedGif;
+      this.hasVideos = !videos.isEmpty();
+      this.videos = videos;
+      this.combinedVideo = combinedVideo;
       this.exception = exception;
     }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/html/HtmlUtils.java
@@ -127,6 +127,13 @@ final class HtmlUtils {
     return new Screenshot(relativePath, caption);
   }
 
+  /** Get a HTML representation of a video with respect to {@code output} directory. */
+  static Video getVideo(File video, File output) {
+    String relativePath = createRelativeUri(video, output);
+    String name = video.getName();
+    return new Video(relativePath, name);
+  }
+
   public static HtmlUtils.SavedFile getFile(File file, File output) {
     return new SavedFile(createRelativeUri(file, output), file.getName());
   }
@@ -190,6 +197,20 @@ final class HtmlUtils {
       this.id = ID.getAndIncrement();
       this.path = path;
       this.caption = caption;
+    }
+  }
+
+  static final class Video {
+    private static final AtomicLong ID = new AtomicLong(0);
+
+    private final long id;
+    public final String path;
+    public final String name;
+
+    Video(String path, String name) {
+      this.id = ID.incrementAndGet();
+      this.path = path;
+      this.name = name;
     }
   }
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/main.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/main.kt
@@ -24,6 +24,8 @@ fun main(vararg args: String) {
     cli.initScript?.let(this::setInitScript)
     setGrantAll(cli.grantAll)
     setNoAnimations(cli.disableGif)
+    setRecordVideo(cli.recordVideo)
+    setNoCombinedVideo(cli.disabledCombinedVideo)
     cli.adbTimeout?.let(this::setAdbTimeout)
     cli.serials.forEach { addDevice(it) }
     cli.skipSerials.forEach { skipDevice(it) }

--- a/spoon-runner/src/main/resources/page/device.html
+++ b/spoon-runner/src/main/resources/page/device.html
@@ -61,12 +61,20 @@
                         </a>
                         {{#animatedGif}}
                         <a href="../{{toString}}" title="View as animated GIF" class="pull-right icon">
+                            <svg fill="#000000" height="28" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M0 0h24v24H0z" fill="none"/>
+                                <path d="M11 17c0 .55.45 1 1 1s1-.45 1-1-.45-1-1-1-1 .45-1 1zm0-14v4h2V5.08c3.39.49 6 3.39 6 6.92 0 3.87-3.13 7-7 7s-7-3.13-7-7c0-1.68.59-3.22 1.58-4.42L12 13l1.41-1.41-6.8-6.8v.02C4.42 6.45 3 9.05 3 12c0 4.97 4.02 9 9 9 4.97 0 9-4.03 9-9s-4.03-9-9-9h-1zm7 9c0-.55-.45-1-1-1s-1 .45-1 1 .45 1 1 1 1-.45 1-1zM6 12c0 .55.45 1 1 1s1-.45 1-1-.45-1-1-1-1 .45-1 1z"/>
+                            </svg>
+                        </a>
+                        {{/animatedGif}}
+                        {{#combinedVideo}}
+                        <a href="../{{toString}}" title="View as video" class="pull-right icon">
                             <svg fill="#222" height="28" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M18 4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4h-4z"/>
                                 <path d="M0 0h24v24H0z" fill="none"/>
                             </svg>
                         </a>
-                        {{/animatedGif}}
+                        {{/combinedVideo}}
                     </h2>
                     {{#exception}}
                     <div class="alert alert-error stacktrace {{status}}">

--- a/spoon-runner/src/main/resources/page/test.html
+++ b/spoon-runner/src/main/resources/page/test.html
@@ -38,12 +38,20 @@
                         </a>
                         {{#hasScreenshots}}
                         <a href="../../{{animatedGif}}" title="View as animated GIF" class="pull-right icon">
+                            <svg fill="#000000" height="28" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M0 0h24v24H0z" fill="none"/>
+                                <path d="M11 17c0 .55.45 1 1 1s1-.45 1-1-.45-1-1-1-1 .45-1 1zm0-14v4h2V5.08c3.39.49 6 3.39 6 6.92 0 3.87-3.13 7-7 7s-7-3.13-7-7c0-1.68.59-3.22 1.58-4.42L12 13l1.41-1.41-6.8-6.8v.02C4.42 6.45 3 9.05 3 12c0 4.97 4.02 9 9 9 4.97 0 9-4.03 9-9s-4.03-9-9-9h-1zm7 9c0-.55-.45-1-1-1s-1 .45-1 1 .45 1 1 1 1-.45 1-1zM6 12c0 .55.45 1 1 1s1-.45 1-1-.45-1-1-1-1 .45-1 1z"/>
+                            </svg>
+                        </a>
+                        {{/hasScreenshots}}
+                        {{#combinedVideo}}
+                        <a href="../../{{toString}}" title="View as video" class="pull-right icon">
                             <svg fill="#222" height="28" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M18 4l2 4h-3l-2-4h-2l2 4h-3l-2-4H8l2 4H7L5 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V4h-4z"/>
                                 <path d="M0 0h24v24H0z" fill="none"/>
                             </svg>
                         </a>
-                        {{/hasScreenshots}}
+                        {{/combinedVideo}}
                     </h2>
                     {{#exception}}
                     <div class="alert alert-error stacktrace {{status}}">

--- a/test-app/build.gradle
+++ b/test-app/build.gradle
@@ -75,6 +75,7 @@ android.testVariants.all { testVariant ->
         variantOutputs[0].outputFile,
         '--output', outputDir,
         '--debug',
+        '--record-video'
       ]
       logger.info("Spoon args: $args")
     }


### PR DESCRIPTION
Even though Spoon provides GIFs for quick glance over test flows I found it useful to be able to record videos that capture the whole device screen. When investigating test flakiness caused by various Android system UI popup interruptions - videos help to diagnose the root cause quickly.   

I have been running a variant of the proposed screen recorder on the instrumentation side using [executeShellCommand](https://developer.android.com/reference/android/app/UiAutomation.html#executeShellCommand(java.lang.String)) successfully however I wanted something more reliable - something that is controlled by the host runner. It appeared to me that this multi segment `screenrecord` command approach can be executed on the spoon-runner side so I thought why not try that!

This PR adds an optional (disabled by default) video recording functionality that, when enabled, produces videos in the *mp4* format that get attached to test reports. Since Android's `screenrecord` command can record only up to 3 minutes `ScreenRecorder` class takes care of executing the command multiple times sequentially. If multiple video files are produced (long test case) they are pulled from the device and Google's `isoparser` library is used to combine all files into a single, continuous video.