### PR TITLE
Fixed junit reports

### DIFF
--- a/spoon-runner/src/main/java/com/squareup/spoon/XmlTestRunListener.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/XmlTestRunListener.java
@@ -17,6 +17,11 @@ class XmlTestRunListener extends com.android.ddmlib.testrunner.XmlTestRunListene
     this.file = file;
   }
 
+  @Override
+  public void testRunStarted(String runName, int numTests) {
+    getRunResult().testRunStarted(runName, numTests);
+  }
+
   @Override protected File getResultFile(File reportDir) throws IOException {
     file.getParentFile().mkdirs();
     return file;


### PR DESCRIPTION
I believe this is a fix of issue [498](https://github.com/square/spoon/issues/498) . The problem was that each time a junit test was executed it was not aggregated to the previous but was overriding it.