### PR TITLE
Fixing spoon-runner CliArgsTest on Windows

### DIFF
--- a/spoon-runner/src/test/java/com/squareup/spoon/CliArgsTest.kt
+++ b/spoon-runner/src/test/java/com/squareup/spoon/CliArgsTest.kt
@@ -3,6 +3,7 @@ package com.squareup.spoon
 import com.google.common.truth.Truth.assertThat
 import com.xenomachina.argparser.ArgParser
 import com.xenomachina.argparser.SystemExitException
+import java.io.File;
 import org.junit.Test
 
 
@@ -27,7 +28,7 @@ class CliArgsTest {
     assertThat(cliArgs.otherApks[0].name).isEqualTo("app.apk")
     assertThat(cliArgs.instrumentationArgs?.get("package"))
         .isEqualTo("com.sample.testsuites")
-    assertThat(cliArgs.output?.path).isEqualTo("outputs/spoon")
+    assertThat(cliArgs.output?.path).isEqualTo("outputs" + File.separator + "spoon")
   }
 
   @Test
@@ -43,7 +44,7 @@ class CliArgsTest {
 
     assertThat(cliArgs.testApk.name).isEqualTo("app-androidTest.apk")
     assertThat(cliArgs.otherApks[0].name).isEqualTo("app.apk")
-    assertThat(cliArgs.output?.path).isEqualTo("outputs/spoon")
+    assertThat(cliArgs.output?.path).isEqualTo("outputs" + File.separator + "spoon")
     assertThat(cliArgs.instrumentationArgs).isNull()
   }
 


### PR DESCRIPTION
There was hardcoded '/' file separator. I used File.separator instead.