### PR TITLE
Allow clients to define their own screenshot provider

### DIFF
--- a/spoon-client/src/main/java/com/squareup/spoon/ScreenshotProvider.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/ScreenshotProvider.java
@@ -1,0 +1,7 @@
+package com.squareup.spoon;
+
+import android.graphics.Bitmap;
+
+public interface ScreenshotProvider {
+  Bitmap capture();
+}

--- a/spoon-client/src/main/java/com/squareup/spoon/SpoonRule.java
+++ b/spoon-client/src/main/java/com/squareup/spoon/SpoonRule.java
@@ -58,7 +58,16 @@ public final class SpoonRule implements TestRule {
     return base; // Pass-through. We're just here to capture the description information.
   }
 
-  public File screenshot(Activity activity, String tag) {
+  public File screenshot(final Activity activity, final String tag) {
+    return screenshot(activity, tag, new ScreenshotProvider() {
+      @Override
+      public Bitmap capture() {
+        return Screenshot.capture(tag, activity);
+      }
+    });
+  }
+
+  public File screenshot(final Activity activity, final String tag, final ScreenshotProvider screenshotProvider) {
     if (!TAG_VALIDATION.matcher(tag).matches()) {
       throw new IllegalArgumentException("Tag must match " + TAG_VALIDATION.pattern() + ".");
     }
@@ -66,7 +75,7 @@ public final class SpoonRule implements TestRule {
         obtainDirectory(activity.getApplicationContext(), className, methodName, SPOON_SCREENSHOTS);
     String screenshotName = System.currentTimeMillis() + NAME_SEPARATOR + tag + EXTENSION;
     File screenshotFile = new File(screenshotDirectory, screenshotName);
-    Bitmap bitmap = Screenshot.capture(tag, activity);
+    Bitmap bitmap = screenshotProvider.capture();
     writeBitmapToFile(bitmap, screenshotFile);
     Log.d(TAG, "Captured screenshot '" + tag + "'.");
     return screenshotFile;


### PR DESCRIPTION
It's a very simple solution (too simple?) to use other screenshot libraries with Spoon. Let's take Falcon for example:
```java
spoon.screenshot(activity, "tag", new ScreenshotProvider() {
    @Override
    public Bitmap capture() {
        return Falcon.takeScreenshotBitmap(activity);
    }
});
```
It would be great to have that possibility.