### PR TITLE
Fix maven links after Maven Search site refresh

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -71,7 +71,7 @@ Spoon.screenshot(activity, "after_login");</pre>
             <p>You can also view each test's screenshots as an animated GIF to gauge the actual sequence of interaction.</p>
 
             <h3 id="download">Download</h3>
-            <p><a href="https://search.maven.org/remote_content?g=com.squareup.spoon&a=spoon-runner&v=LATEST&c=jar-with-dependencies" class="dl runner-version-href">&darr; <span class="version-tag">Latest</span> Runner JAR</a> <a href="https://search.maven.org/remote_content?g=com.squareup.spoon&a=spoon-client&v=LATEST" class="dl client-version-href">&darr; <span class="version-tag">Latest</span> Client JAR</a></p>
+            <p><a href="https://search.maven.org/classic/remote_content?g=com.squareup.spoon&a=spoon-runner&v=LATEST&c=jar-with-dependencies" class="dl runner-version-href">&darr; <span class="version-tag">Latest</span> Runner JAR</a> <a href="https://search.maven.org/classic/remote_content?g=com.squareup.spoon&a=spoon-client&v=LATEST" class="dl client-version-href">&darr; <span class="version-tag">Latest</span> Client JAR</a></p>
 
             <p>The source code to the runner, client library, and sample applications as well as this website is <a href="http://github.com/square/spoon">available on GitHub</a>.</p>
 


### PR DESCRIPTION
Old search queries still works with https://search.maven.org/classic/

Runner JAR doesn't work on current site due to JS maven script not updating its url