### PR TITLE
[bug] Coverage files getting overwritten for non --single-instrumentation-call Spoon task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ jdk:
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.
-  - mkdir "$ANDROID_HOME/licenses" || true
-  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - yes | sdkmanager --update
 
 script:
   - ./gradlew build --no-daemon

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -63,7 +63,9 @@
     <module name="LineLength">
       <property name="max" value="100"/>
     </module>
-    <module name="MethodLength"/>
+    <module name="MethodLength">
+      <property name="max" value="160"/>
+    </module>
     <!--module name="ParameterNumber"/-->
 
 

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -394,28 +394,17 @@ public final class SpoonDeviceRunner {
   }
 
   private void pullCoverageFile(IDevice device) {
-    coverageDir.mkdirs();
-    File coverageFile = new File(coverageDir, COVERAGE_FILE);
-    String remotePath;
-    try {
-      remotePath = getExternalStoragePath(device, COVERAGE_FILE);
-    } catch (Exception exception) {
-      throw new RuntimeException("error while calculating coverage file path.", exception);
-    }
-    adbPullFile(device, remotePath, coverageFile.getAbsolutePath());
+    doPullCoverageFile(device, COVERAGE_FILE);
   }
 
-  /**
-   * Pulls coverage file from external storage of device and saves it in local with test description
-   *
-   * @param device
-   * @param testIdentifier
-   */
   private void pullCoverageFile(IDevice device, String testIdentifier) {
+    doPullCoverageFile(device, testIdentifier + "_" + COVERAGE_FILE);
+  }
+
+  private void doPullCoverageFile(IDevice device, String localFileName) {
     coverageDir.mkdirs();
-    File coverageFile = new File(coverageDir, testIdentifier + "_" + COVERAGE_FILE);
-    logInfo("Pulling Code Coverage file for %s to %s", testIdentifier,
-            coverageFile.getAbsolutePath());
+    File coverageFile = new File(coverageDir, localFileName);
+    logInfo("Pulling Code Coverage file %s", coverageFile.getAbsolutePath());
     String remotePath;
     try {
       remotePath = getExternalStoragePath(device, COVERAGE_FILE);

--- a/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
+++ b/spoon-runner/src/main/java/com/squareup/spoon/SpoonDeviceRunner.java
@@ -401,6 +401,9 @@ public final class SpoonDeviceRunner {
     doPullCoverageFile(device, testIdentifier + "_" + COVERAGE_FILE);
   }
 
+  /**
+   * Pulls coverage file from device storage and saves it locally
+   */
   private void doPullCoverageFile(IDevice device, String localFileName) {
     coverageDir.mkdirs();
     File coverageFile = new File(coverageDir, localFileName);

--- a/spoon-runner/src/main/java/com/squareup/spoon/coverage.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/coverage.kt
@@ -16,7 +16,9 @@ internal fun mergeCoverageFiles(serials: Set<String>, outputDirectory: File) {
   execFileLoader.save(File(outputDirectory, "$COVERAGE_DIR/merged-coverage.ec"), false)
 }
 
-
+/**
+ * Merges all coverage files inside a folder into a single coverage file
+ */
 @Throws(IOException::class)
 internal fun mergeAllCoverageFiles(covReportsFolder: File) {
   val covFiles = covReportsFolder.listFiles()

--- a/spoon-runner/src/main/java/com/squareup/spoon/coverage.kt
+++ b/spoon-runner/src/main/java/com/squareup/spoon/coverage.kt
@@ -15,3 +15,22 @@ internal fun mergeCoverageFiles(serials: Set<String>, outputDirectory: File) {
   }
   execFileLoader.save(File(outputDirectory, "$COVERAGE_DIR/merged-coverage.ec"), false)
 }
+
+
+@Throws(IOException::class)
+internal fun mergeAllCoverageFiles(covReportsFolder: File) {
+  val covFiles = covReportsFolder.listFiles()
+  if (covFiles == null || covFiles.isEmpty())
+    throw RuntimeException("No coverage file in path")
+  SpoonLogger.logInfo("Merging code coverage files in folder %s", covReportsFolder.absolutePath);
+  val execFileLoader = ExecFileLoader()
+  covFiles.forEach { covReport ->
+      execFileLoader.load(covReport)
+  }
+
+  val mergedCovFile = File(covReportsFolder, COVERAGE_FILE)
+  if (!mergedCovFile.exists())
+    mergedCovFile.createNewFile()
+  execFileLoader.save(mergedCovFile, false)
+  SpoonLogger.logInfo("Merged code coverage file saved in %s", mergedCovFile.absolutePath);
+}

--- a/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.kt
+++ b/spoon-runner/src/test/java/com/squareup/spoon/SpoonCoverageMergerTest.kt
@@ -22,10 +22,28 @@ class SpoonCoverageMergerTest {
     assertTrue(mergedCoverageFile.exists())
   }
 
+  @Test fun shouldMergeMultiInstrumentedCoverageFiles() {
+    val outputDirectory = testFolder.newFolder("coverage")
+    val test1 = "class1_test1"
+    val test2 = "class1_test2"
+    val test3 = "class2_test1"
+    createTemporaryMultiTestsCoverageFiles(test1, test2, test3)
+
+    mergeAllCoverageFiles(outputDirectory)
+    val mergedCoverageFile = File(outputDirectory, "coverage.ec")
+    assertTrue(mergedCoverageFile.exists())
+  }
+
   private fun createTemporaryCoverageFiles(serialId1: String, serialId2: String) {
     testFolder.newFolder("output", "coverage", sanitizeSerial(serialId1))
     testFolder.newFolder("output", "coverage", sanitizeSerial(serialId2))
     testFolder.newFile(format("output/coverage/%s/coverage.ec", sanitizeSerial(serialId1)))
     testFolder.newFile(format("output/coverage/%s/coverage.ec", sanitizeSerial(serialId2)))
+  }
+
+  private fun createTemporaryMultiTestsCoverageFiles(test1: String, test2: String, test3: String) {
+    testFolder.newFile(format("coverage/%s-coverage.ec", test1))
+    testFolder.newFile(format("coverage/%s-coverage.ec", test2))
+    testFolder.newFile(format("coverage/%s-coverage.ec", test3))
   }
 }


### PR DESCRIPTION
The multi instrumented spoon task (where `--single-instrumentation-call` is not provided as an argument) works by running command `adb shell am instrument` [https://developer.android.com/studio/test/command-line#RunTestsDevice](link) for each test case.

If the coverage flag is enabled for spoon task, it will create a coverage file for each test case. This behavior is not causing any problems for `--single-instrumentation-call` tasks. But for multi instrumented tasks, The coverage file of previous test gets replaced when the next test runs because each file have the same name (`coverage.ec`).

This change solves the issue by pulling the file from device after each test runs and in the merging the all the *.ec files into one.

Coverage file for each test will be available to the user with a proper naming convention for debugging purposes.